### PR TITLE
Implement chat branching

### DIFF
--- a/frontend/components/ChatHistoryDrawer.tsx
+++ b/frontend/components/ChatHistoryDrawer.tsx
@@ -12,6 +12,7 @@ import { Link, useNavigate, useParams } from 'react-router';
 import { X, Pin, PinOff, Search, MessageSquare, Plus, Edit2, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Thread } from '@/frontend/dexie/db';
+import BranchIcon from './ui/BranchIcon';
 import { usePinnedThreads } from '@/frontend/hooks/usePinnedThreads';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 
@@ -220,6 +221,7 @@ export default function ChatHistoryDrawer({ children, isOpen, setIsOpen }: ChatH
                   <Pin className="h-3 w-3 text-primary shrink-0" />
                 )}
                 <span className="line-clamp-1 text-sm font-medium">{thread.title}</span>
+                {thread.isBranch && <BranchIcon className="h-3 w-3 shrink-0" />}
               </div>
               <span className="text-xs text-muted-foreground">{formatDate(new Date(thread.lastMessageAt))}</span>
             </div>

--- a/frontend/components/MessageControls.tsx
+++ b/frontend/components/MessageControls.tsx
@@ -2,6 +2,9 @@ import { Dispatch, SetStateAction, useState } from 'react';
 import { Button } from './ui/button';
 import { cn } from '@/lib/utils';
 import { Check, Copy, RefreshCcw, SquarePen } from 'lucide-react';
+import BranchIcon from './ui/BranchIcon';
+import { cloneThreadFromMessage } from '@/frontend/dexie/queries';
+import { useNavigate } from 'react-router';
 import { UIMessage } from 'ai';
 import { UseChatHelpers } from '@ai-sdk/react';
 import { deleteTrailingMessages } from '@/frontend/dexie/queries';
@@ -34,6 +37,7 @@ export default function MessageControls({
   const [copied, setCopied] = useState(false);
   const hasRequiredKeys = useAPIKeyStore((state) => state.hasRequiredKeys());
   const { isMobile } = useIsMobile();
+  const navigate = useNavigate();
 
   const handleCopy = () => {
     navigator.clipboard.writeText(content);
@@ -78,6 +82,11 @@ export default function MessageControls({
     }, 0);
   };
 
+  const handleBranch = async () => {
+    const newId = await cloneThreadFromMessage(threadId, message.id);
+    navigate(`/chat/${newId}`);
+  };
+
   // На мобильных устройствах показываем кнопки только когда isVisible = true
   const shouldShowControls = isMobile ? isVisible : true;
 
@@ -99,6 +108,11 @@ export default function MessageControls({
       {setMode && hasRequiredKeys && (
         <Button variant="ghost" size="icon" onClick={() => setMode('edit')}>
           <SquarePen className="w-4 h-4" />
+        </Button>
+      )}
+      {message.role === 'assistant' && (
+        <Button variant="ghost" size="icon" onClick={handleBranch}>
+          <BranchIcon className="w-4 h-4" />
         </Button>
       )}
       {hasRequiredKeys && (

--- a/frontend/components/ui/BranchIcon.tsx
+++ b/frontend/components/ui/BranchIcon.tsx
@@ -1,0 +1,6 @@
+import { GitBranchPlus } from 'lucide-react';
+import type { SVGProps } from 'react';
+
+export default function BranchIcon(props: SVGProps<SVGSVGElement>) {
+  return <GitBranchPlus {...props} />;
+}

--- a/frontend/dexie/db.ts
+++ b/frontend/dexie/db.ts
@@ -7,6 +7,7 @@ interface Thread {
   createdAt: Date;
   updatedAt: Date;
   lastMessageAt: Date;
+  isBranch?: boolean; // marks thread as a branch of another
 }
 
 interface DBMessage {


### PR DESCRIPTION
## Summary
- add new BranchIcon component
- support marking branch chats in thread schema
- implement cloneThreadFromMessage query
- enable branching from assistant messages via MessageControls
- show branch icon in chat history

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684c58f0e674832baa52f9d95a1450fc