### PR TITLE
Fix mobile input and enable navigation bars

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -12,12 +12,13 @@ import { db } from '@/frontend/dexie/db';
 import { useAPIKeyStore } from '@/frontend/stores/APIKeyStore';
 import { useModelStore } from '@/frontend/stores/ModelStore';
 import SettingsButton from './SettingsButton';
+import ChatNavigationBars from './ChatNavigationBars';
 import { useQuoteShortcuts } from '@/frontend/hooks/useQuoteShortcuts';
 import { useScrollHide } from '@/frontend/hooks/useScrollHide';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 import { Link } from 'react-router';
 import { cn } from '@/lib/utils';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'react-router';
 
 interface ChatProps {
@@ -116,8 +117,25 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
     }
   }, [id, initialMessages, threadId]);
 
+  const scrollToMessage = useCallback(
+    (messageId: string) => {
+      const index = messages.findIndex((m) => m.id === messageId);
+      if (index === -1) return;
+      const nodes = document.querySelectorAll<HTMLDivElement>('div[role="article"]');
+      const target = nodes[index];
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    },
+    [messages]
+  );
+
   return (
     <div className="relative w-full">
+      <ChatNavigationBars
+        messages={messages}
+        scrollToMessage={scrollToMessage}
+      />
       <main
         className={`flex flex-col w-full max-w-3xl pt-10 pb-44 mx-auto transition-all duration-300 ease-in-out relative`}
       >

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -168,7 +168,13 @@ function PureChatInput({
 
   return (
     <>
-      <div className={`fixed w-full max-w-3xl ${messageCount === 0 ? 'md:bottom-auto md:top-1/2 md:transform md:-translate-y-1/2' : 'bottom-0 pb-safe'}`}>
+      <div
+        className={cn(
+          'fixed bottom-0 pb-safe w-full max-w-3xl',
+          messageCount === 0 &&
+            'md:bottom-auto md:top-1/2 md:transform md:-translate-y-1/2'
+        )}
+      >
         <div ref={containerRef} className={cn('relative bg-secondary p-2 pb-0 w-full', messageCount === 0 ? 'rounded-[20px]' : 'rounded-t-[20px]')}>
           {/* Scroll to bottom button */}
           <div className="absolute right-4 -top-12 z-50">

--- a/frontend/components/ChatNavigationBars.tsx
+++ b/frontend/components/ChatNavigationBars.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { useState, useRef, useEffect } from "react"
+import { useState } from "react"
 import { cn } from "@/lib/utils"
 import { UIMessage } from 'ai'
 
@@ -12,20 +12,10 @@ interface ChatNavigationBarsProps {
 
 export default function ChatNavigationBars({ messages, scrollToMessage }: ChatNavigationBarsProps) {
   const [hoveredBar, setHoveredBar] = useState<string | null>(null)
-  const [hoveredBarPosition, setHoveredBarPosition] = useState({ top: 0, left: 0 })
-  const [maxBarLength, setMaxBarLength] = useState(0)
-  const sidebarRef = useRef<HTMLDivElement>(null)
 
   // Фильтруем только пользовательские сообщения для навигации
   const userMessages = messages.filter(message => message.role === 'user')
 
-  // Вычисляем максимальную длину полоски при монтировании компонента
-  useEffect(() => {
-    if (userMessages.length > 0) {
-      const maxLength = Math.max(...userMessages.map((message) => getBarLength(message.content.length)))
-      setMaxBarLength(maxLength)
-    }
-  }, [userMessages])
 
   // Функция для вычисления длины полоски на основе длины сообщения
   const getBarLength = (messageLength: number) => {
@@ -46,16 +36,8 @@ export default function ChatNavigationBars({ messages, scrollToMessage }: ChatNa
     return { preview, isShort }
   }
 
-  const handleMouseEnter = (messageId: string, event: React.MouseEvent<HTMLDivElement>) => {
+  const handleMouseEnter = (messageId: string) => {
     setHoveredBar(messageId)
-
-    const barElement = event.currentTarget
-    const rect = barElement.getBoundingClientRect()
-
-    setHoveredBarPosition({
-      top: rect.top + rect.height / 2,
-      left: sidebarRef.current ? sidebarRef.current.getBoundingClientRect().left + maxBarLength : rect.right,
-    })
   }
 
   const handleMouseLeave = () => {
@@ -72,80 +54,42 @@ export default function ChatNavigationBars({ messages, scrollToMessage }: ChatNa
   }
 
   return (
-    <>
-      {/* Навигационные полоски */}
-      <div ref={sidebarRef} className="fixed left-0 top-0 w-16 h-full flex flex-col items-start justify-center py-4 space-y-3 pl-2 z-30">
-        {userMessages.map((message) => {
-          const barLength = getBarLength(message.content.length)
+    <div className="fixed left-0 top-0 z-30 flex h-full w-16 flex-col items-start justify-center space-y-3 py-4 pl-2">
+      {userMessages.map((message) => {
+        const barLength = getBarLength(message.content.length)
+        const { preview, isShort } = getMessagePreview(message.content)
+        const isHovered = hoveredBar === message.id
 
-          return (
-            <div
-              key={message.id}
-              className={cn(
-                "bg-blue-500/60 hover:bg-blue-500 dark:bg-blue-400/60 dark:hover:bg-blue-400 transition-all duration-200 cursor-pointer rounded-r-full",
-                "hover:shadow-md",
-                "will-change-transform-shadow transition-property-all"
-              )}
-              style={{
-                width: `${barLength}px`,
-                height: "4px",
-              }}
-              onMouseEnter={(e) => handleMouseEnter(message.id, e)}
-              onMouseLeave={handleMouseLeave}
-              onClick={() => handleBarClick(message.id)}
-            />
-          )
-        })}
-
-        {/* Всплывающая плитка с превью */}
-        {hoveredBar &&
-          (() => {
-            const messageData = userMessages.find((m) => m.id === hoveredBar)
-            if (!messageData) return null
-            
-            const { preview, isShort } = getMessagePreview(messageData.content)
-
-            return (
-              <div
-                className="fixed z-50 overflow-hidden pointer-events-none"
-                style={{
-                  left: hoveredBarPosition.left + 16,
-                  top: hoveredBarPosition.top,
-                  transform: "translateY(-50%)",
-                  width: isShort ? "160px" : "240px",
-                  height: isShort ? "48px" : "72px",
-                }}
+        return (
+          <div
+            key={message.id}
+            className={cn(
+              'bg-blue-500/60 hover:bg-blue-500 dark:bg-blue-400/60 dark:hover:bg-blue-400 transition-all duration-200 cursor-pointer',
+              isHovered
+                ? 'rounded-xl flex items-center justify-center shadow-md'
+                : 'rounded-r-full hover:shadow-md will-change-transform-shadow transition-property-all'
+            )}
+            style={{
+              width: isHovered ? (isShort ? '160px' : '240px') : `${barLength}px`,
+              height: isHovered ? (isShort ? '48px' : '72px') : '4px'
+            }}
+            onMouseEnter={() => handleMouseEnter(message.id)}
+            onMouseLeave={handleMouseLeave}
+            onClick={() => handleBarClick(message.id)}
+          >
+            {isHovered && (
+              <span
+                className={cn(
+                  'text-gray-800 dark:text-white font-medium',
+                  isShort ? 'text-sm' : 'text-sm leading-tight'
+                )}
               >
-                {/* Основной контейнер с стекломорфизмом */}
-                <div className="relative w-full h-full bg-gradient-to-br from-white/90 via-white/80 to-white/70 dark:from-gray-900/80 dark:via-gray-800/70 dark:to-gray-700/60 backdrop-blur-xl rounded-xl border border-gray-200/60 dark:border-white/20 shadow-2xl shadow-black/10 dark:shadow-black/40">
-                  {/* Внутренний градиент для глубины */}
-                  <div className="absolute inset-0 bg-gradient-to-br from-white/20 dark:from-white/10 to-transparent rounded-xl"></div>
-
-                  {/* Верхний туман */}
-                  <div className="absolute top-0 left-0 right-0 h-4 bg-gradient-to-b from-white/95 via-white/60 dark:from-gray-900/90 dark:via-gray-900/40 to-transparent z-10 rounded-t-xl"></div>
-
-                  {/* Контейнер с текстом */}
-                  <div className="relative flex items-center justify-center h-full px-4">
-                    <div
-                      className={cn(
-                        "text-gray-800 dark:text-white text-center font-medium",
-                        isShort ? "text-sm" : "text-sm leading-tight",
-                      )}
-                    >
-                      {preview}
-                    </div>
-                  </div>
-
-                  {/* Нижний туман */}
-                  <div className="absolute bottom-0 left-0 right-0 h-4 bg-gradient-to-t from-white/95 via-white/60 dark:from-gray-900/90 dark:via-gray-900/40 to-transparent z-10 rounded-b-xl"></div>
-
-                  {/* Дополнительная подсветка краев */}
-                  <div className="absolute inset-0 rounded-xl ring-1 ring-gray-300/50 dark:ring-white/30 ring-inset"></div>
-                </div>
-              </div>
-            )
-          })()}
-      </div>
-    </>
+                {preview}
+              </span>
+            )}
+          </div>
+        )
+      })}
+    </div>
   )
-} 
+}


### PR DESCRIPTION
## Summary
- pin chat input to bottom of viewport on mobile
- add navigation bar component to chat page
- allow navigating to specific messages
- update navigation bars to expand into preview tile on hover

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684c58e8c028832ba5b5b4b5c3d8a445