### PR TITLE
Fix sidebar import and remove Google font

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -93,9 +93,11 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-  --font-sans: Geist, sans-serif;
+  /* Use locally hosted Proxima Vara as the sans-serif font to avoid fetching from Google */
+  --font-sans: 'Proxima Vara', sans-serif;
   --font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
-  --font-mono: Geist Mono, monospace;
+  /* Berkeley Mono is bundled locally and used as the monospace font */
+  --font-mono: 'Berkeley Mono', monospace;
   --radius: 0.625rem;
   --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
   --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
@@ -144,9 +146,10 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(0.275 0 0);
   --sidebar-ring: oklch(0.439 0 0);
-  --font-sans: Geist, sans-serif;
+  /* Dark theme font overrides using local fonts */
+  --font-sans: 'Proxima Vara', sans-serif;
   --font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
-  --font-mono: Geist Mono, monospace;
+  --font-mono: 'Berkeley Mono', monospace;
   --radius: 0.625rem;
   --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
   --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,8 @@
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import 'katex/dist/katex.min.css';
 import { Toaster } from '@/frontend/components/ui/sonner';
 import Providers from '@/frontend/components/Providers';
-
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
-});
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-});
-
 export const metadata: Metadata = {
   title: 'Pak.Chat',
   description: 'High-Performance LLM Application',
@@ -27,10 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body
-        suppressHydrationWarning={true}
-        className={`${geistSans.variable} ${geistMono.variable} antialiased font-sans`}
-      >
+      <body suppressHydrationWarning={true} className="antialiased font-sans">
         <Providers>
           {children}
           <Toaster richColors position="top-right" />

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -3,7 +3,8 @@ import { Slot } from '@radix-ui/react-slot';
 import { VariantProps, cva } from 'class-variance-authority';
 import { PanelLeftIcon } from 'lucide-react';
 
-import { useIsMobile } from '@/hooks/use-mobile';
+// Hook to detect mobile screen size. Using frontend path for alias compatibility
+import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 import { cn } from '@/lib/utils';
 import { Button } from '@/frontend/components/ui/button';
 import { Input } from '@/frontend/components/ui/input';
@@ -64,7 +65,8 @@ function SidebarProvider({
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }) {
-  const isMobile = useIsMobile();
+  // useIsMobile returns { isMobile, mounted }, we only need the boolean flag.
+  const { isMobile } = useIsMobile();
   const [openMobile, setOpenMobile] = React.useState(false);
 
   // This is the internal state of the sidebar.


### PR DESCRIPTION
## Summary
- fix Sidebar hook import path
- remove Google fonts to avoid blocked downloads
- use local fonts for sans and mono

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c5b7b3cdc832ba8d95c88883cab74