### PR TITLE
Fix font loading

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -93,11 +93,10 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-  /* Use locally hosted Proxima Vara as the sans-serif font to avoid fetching from Google */
-  --font-sans: 'Proxima Vara', sans-serif;
+  /* Default system fonts; overridden via data attributes */
+  --font-sans: system-ui, -apple-system, sans-serif;
   --font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
-  /* Berkeley Mono is bundled locally and used as the monospace font */
-  --font-mono: 'Berkeley Mono', monospace;
+  --font-mono: ui-monospace, 'SF Mono', monospace;
   --radius: 0.625rem;
   --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
   --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
@@ -111,6 +110,15 @@
   --shadow-xl: 0 1px 3px 0px hsl(0 0% 0% / 0.1),
     0 8px 10px -1px hsl(0 0% 0% / 0.1);
   --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
+}
+
+/* Override fonts when user selects custom options */
+html[data-general-font='proxima-vara'] {
+  --font-sans: 'Proxima Vara', sans-serif;
+}
+
+html[data-code-font='berkeley-mono'] {
+  --font-mono: 'Berkeley Mono', monospace;
 }
 
 .dark {
@@ -146,10 +154,10 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(0.275 0 0);
   --sidebar-ring: oklch(0.439 0 0);
-  /* Dark theme font overrides using local fonts */
-  --font-sans: 'Proxima Vara', sans-serif;
+  /* Fonts inherit defaults; can be overridden via data attributes */
+  --font-sans: system-ui, -apple-system, sans-serif;
   --font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
-  --font-mono: 'Berkeley Mono', monospace;
+  --font-mono: ui-monospace, 'SF Mono', monospace;
   --radius: 0.625rem;
   --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
   --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
@@ -223,6 +231,7 @@
     @apply border-border outline-ring/50;
   }
   body {
+    font-family: var(--font-sans);
     @apply bg-background text-foreground;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,23 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Preload custom fonts for faster rendering */}
+        <link
+          rel="preload"
+          as="font"
+          type="font/woff2"
+          href="/fonts/ProximaVara-Regular.woff2"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preload"
+          as="font"
+          type="font/woff2"
+          href="/fonts/BerkeleyMono-Regular.woff2"
+          crossOrigin="anonymous"
+        />
+      </head>
       <body suppressHydrationWarning={true} className="antialiased font-sans">
         <Providers>
           {children}

--- a/frontend/hooks/useSettings.ts
+++ b/frontend/hooks/useSettings.ts
@@ -5,26 +5,17 @@ export function useSettings() {
   const { settings } = useSettingsStore();
 
   useEffect(() => {
-    const applyFontSettings = () => {
-      const root = document.documentElement;
-      
-      // Apply general font
-      if (settings.generalFont === 'Proxima Vara') {
-        root.style.setProperty('--font-sans', 'Proxima Vara, sans-serif');
-      } else {
-        root.style.setProperty('--font-sans', 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif');
-      }
-
-      // Apply code font
-      if (settings.codeFont === 'Berkeley Mono') {
-        root.style.setProperty('--font-mono', 'Berkeley Mono, "JetBrains Mono", "Fira Code", "Cascadia Code", Consolas, monospace');
-      } else {
-        root.style.setProperty('--font-mono', 'ui-monospace, "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, "Courier New", monospace');
-      }
-    };
-
-    applyFontSettings();
+    const root = document.documentElement;
+    // Apply selected fonts using data attributes for CSS hooks
+    root.setAttribute(
+      'data-general-font',
+      settings.generalFont.replace(/\s+/g, '-').toLowerCase()
+    );
+    root.setAttribute(
+      'data-code-font',
+      settings.codeFont.replace(/\s+/g, '-').toLowerCase()
+    );
   }, [settings.generalFont, settings.codeFont]);
 
   return settings;
-} 
+}


### PR DESCRIPTION
## Summary
- preload main fonts in root layout
- switch to data attribute based font management
- update global styles to support data attributes

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684c665609ac832bba2d9b578bbb679b