### PR TITLE
Add useAutoHide hook for message controls

### DIFF
--- a/frontend/components/Message.tsx
+++ b/frontend/components/Message.tsx
@@ -27,6 +27,8 @@ function PureMessage({
   reload,
   isStreaming,
   stop,
+  isControlsVisible,
+  onShowControls,
 }: {
   threadId: string;
   message: UIMessage;
@@ -34,9 +36,10 @@ function PureMessage({
   reload: UseChatHelpers['reload'];
   isStreaming: boolean;
   stop: UseChatHelpers['stop'];
+  isControlsVisible: boolean;
+  onShowControls: () => void;
 }) {
   const [mode, setMode] = useState<'view' | 'edit'>('view');
-  const [mobileControlsVisible, setMobileControlsVisible] = useState(false);
   const isWelcome = message.id === 'welcome';
   const { keys, setKeys } = useAPIKeyStore();
   const [localKeys, setLocalKeys] = useState(keys);
@@ -54,11 +57,6 @@ function PureMessage({
     navigate(`/chat/${newId}`);
   };
 
-  const handleMobileMessageClick = () => {
-    if (isMobile && !isWelcome) {
-      setMobileControlsVisible(!mobileControlsVisible);
-    }
-  };
 
   return (
     <div
@@ -130,7 +128,7 @@ function PureMessage({
                 'relative group px-4 py-3 rounded-xl bg-secondary border border-secondary-foreground/2 max-w-[90%] sm:max-w-[80%] mx-2 sm:mx-0',
                 isMobile && 'cursor-pointer'
               )}
-              onClick={handleMobileMessageClick}
+              onClick={isMobile ? onShowControls : undefined}
             >
               {mode === 'edit' && (
                 <MessageEditor
@@ -154,8 +152,7 @@ function PureMessage({
                   setMessages={setMessages}
                   reload={reload}
                   stop={stop}
-                  isVisible={mobileControlsVisible}
-                  onToggleVisibility={() => setMobileControlsVisible(!mobileControlsVisible)}
+                  isVisible={isMobile ? isControlsVisible : false}
                 />
               )}
             </div>
@@ -166,7 +163,7 @@ function PureMessage({
                 'group flex flex-col gap-2 w-full px-2 sm:px-0',
                 isMobile && 'cursor-pointer'
               )}
-              onClick={handleMobileMessageClick}
+              onClick={isMobile ? onShowControls : undefined}
             >
               <SelectableText messageId={message.id} disabled={isStreaming}>
                 <MarkdownRenderer content={part.text} id={message.id} />
@@ -179,8 +176,7 @@ function PureMessage({
                   setMessages={setMessages}
                   reload={reload}
                   stop={stop}
-                  isVisible={mobileControlsVisible}
-                  onToggleVisibility={() => setMobileControlsVisible(!mobileControlsVisible)}
+                  isVisible={isMobile ? isControlsVisible : false}
                 />
               )}
             </div>
@@ -195,6 +191,7 @@ const PreviewMessage = memo(PureMessage, (prevProps, nextProps) => {
   if (prevProps.isStreaming !== nextProps.isStreaming) return false;
   if (prevProps.message.id !== nextProps.message.id) return false;
   if (!equal(prevProps.message.parts, nextProps.message.parts)) return false;
+  if (prevProps.isControlsVisible !== nextProps.isControlsVisible) return false;
   return true;
 });
 

--- a/frontend/components/Messages.tsx
+++ b/frontend/components/Messages.tsx
@@ -5,6 +5,7 @@ import { UseChatHelpers } from '@ai-sdk/react';
 import equal from 'fast-deep-equal';
 import MessageLoading from './ui/MessageLoading';
 import Error from './Error';
+import useAutoHide from '../hooks/useAutoHide';
 
 function PureMessages({
   threadId,
@@ -23,6 +24,7 @@ function PureMessages({
   error: UseChatHelpers['error'];
   stop: UseChatHelpers['stop'];
 }) {
+  const { id: activeControlsId, show: showControls } = useAutoHide(800);
   return (
     <section className="flex flex-col space-y-12">
       {messages.map((message, index) => (
@@ -34,6 +36,8 @@ function PureMessages({
           setMessages={setMessages}
           reload={reload}
           stop={stop}
+          isControlsVisible={activeControlsId === message.id}
+          onShowControls={() => showControls(message.id)}
         />
       ))}
       {status === 'submitted' && <MessageLoading />}

--- a/frontend/hooks/useAutoHide.ts
+++ b/frontend/hooks/useAutoHide.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Manages the visibility of controls for messages.
+ * Only one set of controls can be visible at a time.
+ * @param delay Time in ms after which controls should auto-hide.
+ */
+export default function useAutoHide(delay: number) {
+  const [id, setId] = useState<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const show = useCallback((nextId: string) => {
+    setId(nextId);
+
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setId(null), delay);
+  }, [delay]);
+
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+  }, []);
+
+  return { id, show } as const;
+}


### PR DESCRIPTION
## Summary
- implement `useAutoHide` hook to manage visible message controls
- show/hide controls from `Messages` with the new hook
- refactor `Message` to use `useAutoHide` state

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684c664cdac4832b939f98aa3055d6a0