### PR TITLE
Install Cypress React and configure tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "zustand": "^5.0.5"
   },
   "devDependencies": {
+    "@cypress/react": "^9.0.1",
     "@eslint/eslintrc": "^3.3.1",
     "@tailwindcss/postcss": "^4.1.8",
     "@tailwindcss/typography": "^0.5.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(@types/react@19.1.6)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
     devDependencies:
+      '@cypress/react':
+        specifier: ^9.0.1
+        version: 9.0.1(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(cypress@14.4.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@eslint/eslintrc':
         specifier: ^3.3.1
         version: 3.3.1
@@ -641,6 +644,18 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@cypress/react@9.0.1':
+    resolution: {integrity: sha512-qu6ziP2smdlfy3Yvrhm6PadxEtkc/cl6YhZu3h6KCtz+0s54joqxp6uGYOglpwyMBp3qjtSil1JVlFX0hUi5LQ==}
+    peerDependencies:
+      '@types/react': ^18 || ^19
+      '@types/react-dom': ^18 || ^19
+      cypress: '*'
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@cypress/request@3.0.8':
     resolution: {integrity: sha512-h0NFgh1mJmm1nr4jCwkGHwKneVYKghUyWe6TMNrk0B9zsjAJxpg8C4/+BAcmLgCPa1vj1V8rNUaILl+zYRUWBQ==}
@@ -6308,6 +6323,15 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@cypress/react@9.0.1(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(cypress@14.4.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@types/react-dom': 19.1.6(@types/react@19.1.6)
+      cypress: 14.4.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.6
 
   '@cypress/request@3.0.8':
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "types": ["cypress", "@cypress/react"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- add `@cypress/react` dev dependency for Cypress tests
- configure `tsconfig.json` to include Cypress types

## Testing
- `pnpm lint`
- `pnpm test:e2e` *(fails: Webpack compilation error)*

------
https://chatgpt.com/codex/tasks/task_e_684c864529b0832bb99ac4a6d5f5a76e