### PR TITLE
Fix cookie retrieval in RootLayout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,13 +20,17 @@ export const viewport: Viewport = {
   viewportFit: 'cover',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const generalFontCookie = cookies().get('general-font')?.value || 'Inter';
-  const codeFontCookie = cookies().get('code-font')?.value || 'JetBrains Mono';
+  // Сначала "дожидаемся" получения объекта с куками
+  const cookieStore = await cookies();
+
+  // Теперь безопасно вызываем .get() у полученного объекта
+  const generalFontCookie = cookieStore.get('general-font')?.value || 'Inter';
+  const codeFontCookie = cookieStore.get('code-font')?.value || 'JetBrains Mono';
 
   const generalFontClass = `font-sans-${generalFontCookie.replace(/\s+/g, '-').toLowerCase()}`;
   const codeFontClass = `font-mono-${codeFontCookie.replace(/\s+/g, '-').toLowerCase()}`;


### PR DESCRIPTION
## Summary
- make `RootLayout` async
- await cookie store then read cookies
- clarify code with comments

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_684c9daedee8832b91cef8cb9cd36312