### PR TITLE
Fix build fonts retrieval and framer-motion typing

### DIFF
--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,14 +1,36 @@
-import { Inter, JetBrains_Mono } from 'next/font/google';
+import localFont from 'next/font/local';
 
-// Initialize Google Fonts with CSS variables
-export const inter = Inter({
-  subsets: ['latin'],
+// Use locally installed fonts from @fontsource packages to avoid network fetches
+export const inter = localFont({
+  src: [
+    {
+      path: '../node_modules/@fontsource/inter/files/inter-latin-400-normal.woff2',
+      weight: '400',
+      style: 'normal',
+    },
+    {
+      path: '../node_modules/@fontsource/inter/files/inter-latin-700-normal.woff2',
+      weight: '700',
+      style: 'normal',
+    },
+  ],
   variable: '--font-inter',
   display: 'swap',
 });
 
-export const jetbrainsMono = JetBrains_Mono({
-  subsets: ['latin'],
+export const jetbrainsMono = localFont({
+  src: [
+    {
+      path: '../node_modules/@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff2',
+      weight: '400',
+      style: 'normal',
+    },
+    {
+      path: '../node_modules/@fontsource/jetbrains-mono/files/jetbrains-mono-latin-700-normal.woff2',
+      weight: '700',
+      style: 'normal',
+    },
+  ],
   variable: '--font-jetbrains-mono',
   display: 'swap',
 });

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -10,7 +10,7 @@ import { Link } from 'react-router';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 import { useUIStore } from '@/frontend/stores/uiStore';
 import { useScrollHide } from '@/frontend/hooks/useScrollHide';
-import { motion } from 'framer-motion';
+import { motion, type Transition, easeInOut } from 'framer-motion';
 // additional imports from previous version
 import { UIMessage } from 'ai';
 import { v4 as uuidv4 } from 'uuid';
@@ -105,7 +105,8 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
     hiddenRight: { opacity: 0, x: '110%' },
     partialRight: { x: '48px' },
   } as const;
-  const transition = { duration: 0.3, ease: 'easeInOut' };
+  // Animation transition settings using framer-motion's easeInOut for smooth motion
+  const transition: Transition = { duration: 0.3, ease: easeInOut };
 
   return (
     <div className="w-full h-screen flex flex-col overflow-hidden">

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@ai-sdk/google": "^1.2.19",
     "@ai-sdk/openai": "^1.3.22",
     "@ai-sdk/react": "^1.2.12",
+    "@fontsource/inter": "^5.2.6",
+    "@fontsource/jetbrains-mono": "^5.2.6",
     "@hookform/resolvers": "^5.0.1",
     "@opennextjs/cloudflare": "^1.2.1",
     "@openrouter/ai-sdk-provider": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@ai-sdk/react':
         specifier: ^1.2.12
         version: 1.2.12(react@19.1.0)(zod@3.25.56)
+      '@fontsource/inter':
+        specifier: ^5.2.6
+        version: 5.2.6
+      '@fontsource/jetbrains-mono':
+        specifier: ^5.2.6
+        version: 5.2.6
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.0.1(react-hook-form@7.57.0(react@19.1.0))
@@ -870,6 +876,12 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@fontsource/inter@5.2.6':
+    resolution: {integrity: sha512-CZs9S1CrjD0jPwsNy9W6j0BhsmRSQrgwlTNkgQXTsAeDRM42LBRLo3eo9gCzfH4GvV7zpyf78Ozfl773826csw==}
+
+  '@fontsource/jetbrains-mono@5.2.6':
+    resolution: {integrity: sha512-nz//dBr99hXZmHp10wgNI00qThWImkzRR5PQjvRM+rpmuHO5rYBJCqPPWufidCvmkkryXx/GOP/lgqsM3R3Org==}
 
   '@hookform/resolvers@5.0.1':
     resolution: {integrity: sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==}
@@ -6081,6 +6093,10 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@fontsource/inter@5.2.6': {}
+
+  '@fontsource/jetbrains-mono@5.2.6': {}
 
   '@hookform/resolvers@5.0.1(react-hook-form@7.57.0(react@19.1.0))':
     dependencies:


### PR DESCRIPTION
## Summary
- use framer-motion easeInOut transition type in Chat
- host fonts locally using @fontsource packages

## Testing
- `pnpm run build`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c9eb8f064832b8c54240cca71c2c3