### PR TITLE
Refactor header layout

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -99,50 +99,52 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
 
 
   // framer-motion animation settings
+  // Animation states for header controls
   const animationVariants = {
     visible: { opacity: 1, x: 0, y: 0 },
     hiddenLeft: { opacity: 0, x: '-110%' },
     hiddenRight: { opacity: 0, x: '110%' },
-    partialRight: { x: '48px' },
+    fade: { opacity: 0, x: 0 }, // fades out without horizontal shift
   } as const;
   const transition = { duration: 0.3, ease: 'easeInOut' };
 
   return (
     <div className="w-full h-screen flex flex-col overflow-hidden">
       <header className="relative z-20 shrink-0">
-        <motion.div
-          className="fixed left-4 top-4"
-          initial="visible"
-          animate={isMobile && shouldHideHeader ? 'hiddenLeft' : 'visible'}
-          variants={animationVariants}
-          transition={transition}
-        >
-          <Link to="/chat" className="text-xl font-bold">
-            Pak.Chat
-          </Link>
-        </motion.div>
-
-        <div className="fixed right-4 top-4 flex items-center gap-2">
-          <motion.div initial="visible" animate="visible" transition={transition}>
-            {hasKeys && <NewChatButton />}
-          </motion.div>
-          <motion.div initial="visible" animate="visible" transition={transition}>
-            <ChatHistoryButton />
-          </motion.div>
+        <div className="fixed left-4 right-4 top-4 flex items-center gap-x-1">
           <motion.div
             initial="visible"
-            animate={
-              isMobile && isEditing
-                ? 'hiddenRight'
-                : isMobile && scrollHidden
-                  ? 'partialRight'
-                  : 'visible'
-            }
+            animate={isMobile && shouldHideHeader ? 'hiddenLeft' : 'visible'}
             variants={animationVariants}
             transition={transition}
           >
-            <SettingsButton />
+            <Link to="/chat" className="text-xl font-bold">
+              Pak.Chat
+            </Link>
           </motion.div>
+
+          <div className="ml-auto flex items-center gap-x-1">
+            <motion.div initial="visible" animate="visible" transition={transition}>
+              {hasKeys && <NewChatButton />}
+            </motion.div>
+            <motion.div initial="visible" animate="visible" transition={transition}>
+              <ChatHistoryButton />
+            </motion.div>
+            <motion.div
+              initial="visible"
+              animate={
+                isMobile && isEditing
+                  ? 'hiddenRight'
+                  : isMobile && scrollHidden
+                    ? 'fade'
+                    : 'visible'
+              }
+              variants={animationVariants}
+              transition={transition}
+            >
+              <SettingsButton />
+            </motion.div>
+          </div>
         </div>
       </header>
 

--- a/frontend/components/SettingsButton.tsx
+++ b/frontend/components/SettingsButton.tsx
@@ -27,7 +27,12 @@ export default function SettingsButton({
           <Button
             variant={variant}
             size={size}
-            className={cn("bg-background/80 backdrop-blur-sm border-border/50", className)}
+            className={cn(
+              'bg-background/80 backdrop-blur-sm border-border/50',
+              // pseudo-element creates a left divider
+              'relative before:absolute before:-left-px before:inset-y-1 before:w-px before:bg-border/50',
+              className
+            )}
             aria-label="Open settings"
             onClick={() => setIsOpen(true)}
           >


### PR DESCRIPTION
## Summary
- simplify chat header layout so all controls share a single flex wrapper
- fade settings button when header is hidden
- add pseudo left divider on Settings button

## Testing
- `pnpm lint`
- `pnpm build` *(fails: failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684ca9dc4014832ba4284a9dec11034d