### PR TITLE
Improve mobile viewport handling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -325,6 +325,19 @@ html, body {
   .mobile-settings-content {
     padding-bottom: calc(env(safe-area-inset-bottom) + 2rem);
   }
+
+  /* Высота с учетом динамического viewport на мобильных */
+  @media (max-width: 768px) {
+    .mobile-vh {
+      height: 100vh;
+    }
+
+    @supports (height: 100dvh) {
+      .mobile-vh {
+        height: 100dvh;
+      }
+    }
+  }
   
   /* Исправление для мобильных устройств - предотвращение зума при фокусе на input */
   @media screen and (max-width: 768px) {

--- a/frontend/ChatLayout.tsx
+++ b/frontend/ChatLayout.tsx
@@ -1,8 +1,12 @@
 import { Outlet } from 'react-router';
+import { cn } from '@/lib/utils';
 
-export default function ChatLayout() {
+interface ChatLayoutProps {
+  isMobile: boolean;
+}
+export default function ChatLayout({ isMobile }: ChatLayoutProps) {
   return (
-    <div className="w-full h-full">
+    <div className={cn('w-full h-full', isMobile && 'overflow-hidden')}>
       <Outlet />
     </div>
   );

--- a/frontend/app.tsx
+++ b/frontend/app.tsx
@@ -1,16 +1,18 @@
 import { BrowserRouter, Route, Routes } from 'react-router';
 import ChatLayout from './ChatLayout';
+import { useIsMobile } from './hooks/useIsMobile';
 import Home from './routes/Home';
 import Index from './routes/Index';
 import Thread from './routes/Thread';
 import Settings from './routes/Settings';
 
 export default function App() {
+  const { isMobile } = useIsMobile();
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Index />} />
-        <Route path="chat" element={<ChatLayout />}>
+        <Route path="chat" element={<ChatLayout isMobile={isMobile} />}>
           <Route index element={<Home />} />
           <Route path=":id" element={<Thread />} />
         </Route>

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -8,6 +8,7 @@ import NewChatButton from './NewChatButton';
 import SettingsButton from './SettingsButton';
 import { Link } from 'react-router';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
+import { cn } from '@/lib/utils';
 import { useUIStore } from '@/frontend/stores/uiStore';
 import { useScrollHide } from '@/frontend/hooks/useScrollHide';
 import { motion } from 'framer-motion';
@@ -108,7 +109,9 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
   const transition = { duration: 0.3, ease: 'easeInOut' };
 
   return (
-    <div className="w-full h-screen flex flex-col overflow-hidden">
+    <div className={cn(
+      "w-full flex flex-col overflow-hidden h-screen mobile-vh"
+    )}>
       <header className="relative z-20 shrink-0">
         <motion.div
           className="fixed left-4 top-4"


### PR DESCRIPTION
## Summary
- add `mobile-vh` utility for mobile `100dvh` height with fallback
- pass `isMobile` prop into `ChatLayout`
- apply new `mobile-vh` class in `Chat` component
- disable layout scrolling on mobile

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684ca9ec78f0832baf6e926b1441e249