### PR TITLE
Implement custom fonts

### DIFF
--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,14 +1,12 @@
-import { Inter, JetBrains_Mono } from 'next/font/google';
-
-// Initialize Google Fonts with CSS variables
-export const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-inter',
-  display: 'swap',
-});
-
-export const jetbrainsMono = JetBrains_Mono({
-  subsets: ['latin'],
-  variable: '--font-jetbrains-mono',
-  display: 'swap',
-});
+/**
+ * Paths of font files that should be preloaded. Only the woff2 variants are
+ * used to minimise network overhead.
+ */
+export const fontPreloads = [
+  '/fonts/ProximaVara-Regular.woff2',
+  '/fonts/ProximaVara-Medium.woff2',
+  '/fonts/ProximaVara-Semibold.woff2',
+  '/fonts/BerkeleyMono-Regular.woff2',
+  '/fonts/BerkeleyMono-Medium.woff2',
+  '/fonts/BerkeleyMono-Bold.woff2',
+];

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,61 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Custom font faces */
+@font-face {
+  font-family: 'Proxima Vara';
+  src: url('/fonts/ProximaVara-Regular.woff2') format('woff2'),
+       url('/fonts/ProximaVara-Regular.woff') format('woff');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Proxima Vara';
+  src: url('/fonts/ProximaVara-Medium.woff2') format('woff2'),
+       url('/fonts/ProximaVara-Medium.woff') format('woff');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Proxima Vara';
+  src: url('/fonts/ProximaVara-Semibold.woff2') format('woff2'),
+       url('/fonts/ProximaVara-Semibold.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Berkeley Mono';
+  src: url('/fonts/BerkeleyMono-Regular.woff2') format('woff2'),
+       url('/fonts/BerkeleyMono-Regular.woff') format('woff');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Berkeley Mono';
+  src: url('/fonts/BerkeleyMono-Medium.woff2') format('woff2'),
+       url('/fonts/BerkeleyMono-Medium.woff') format('woff');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Berkeley Mono';
+  src: url('/fonts/BerkeleyMono-Bold.woff2') format('woff2'),
+       url('/fonts/BerkeleyMono-Bold.woff') format('woff');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
 /* Prevent horizontal scrollbars */
 html, body {
   max-width: 100%;
@@ -44,10 +99,12 @@ html, body {
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-  /* Default system fonts overridable via CSS classes */
-  --font-sans: system-ui, -apple-system, sans-serif;
+  /* Font variables */
+  --font-proxima-vara: 'Proxima Vara', sans-serif;
+  --font-berkeley-mono: 'Berkeley Mono', monospace;
+  --font-sans: var(--font-proxima-vara);
   --font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
-  --font-mono: ui-monospace, 'SF Mono', monospace;
+  --font-mono: var(--font-berkeley-mono);
   --radius: 0.625rem;
   --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
   --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
@@ -96,10 +153,12 @@ html, body {
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(0.275 0 0);
   --sidebar-ring: oklch(0.439 0 0);
-  /* Default system fonts overridable via CSS classes */
-  --font-sans: system-ui, -apple-system, sans-serif;
+  /* Font variables */
+  --font-proxima-vara: 'Proxima Vara', sans-serif;
+  --font-berkeley-mono: 'Berkeley Mono', monospace;
+  --font-sans: var(--font-proxima-vara);
   --font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
-  --font-mono: ui-monospace, 'SF Mono', monospace;
+  --font-mono: var(--font-berkeley-mono);
   --radius: 0.625rem;
   --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
   --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
@@ -180,10 +239,10 @@ html, body {
 
 @layer utilities {
   /* Font switcher classes */
-  .font-sans-inter { --font-sans: var(--font-inter); }
+  .font-sans-proxima-vara { --font-sans: var(--font-proxima-vara); }
   .font-sans-system-font { --font-sans: system-ui, -apple-system, sans-serif; }
 
-  .font-mono-jetbrains-mono { --font-mono: var(--font-jetbrains-mono); }
+  .font-mono-berkeley-mono { --font-mono: var(--font-berkeley-mono); }
   .font-mono-system-monospace-font { --font-mono: ui-monospace, 'SF Mono', monospace; }
 
   .font-mono { font-family: var(--font-mono) !important; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { inter, jetbrainsMono } from './fonts';
+import { fontPreloads } from './fonts';
 import { cookies } from 'next/headers';
 import './globals.css';
 import 'katex/dist/katex.min.css';
@@ -29,18 +29,26 @@ export default async function RootLayout({
   const cookieStore = await cookies();
 
   // Теперь безопасно вызываем .get() у полученного объекта
-  const generalFontCookie = cookieStore.get('general-font')?.value || 'Inter';
-  const codeFontCookie = cookieStore.get('code-font')?.value || 'JetBrains Mono';
+  const generalFontCookie = cookieStore.get('general-font')?.value || 'Proxima Vara';
+  const codeFontCookie = cookieStore.get('code-font')?.value || 'Berkeley Mono';
 
   const generalFontClass = `font-sans-${generalFontCookie.replace(/\s+/g, '-').toLowerCase()}`;
   const codeFontClass = `font-mono-${codeFontCookie.replace(/\s+/g, '-').toLowerCase()}`;
 
   return (
-    <html
-      lang="en"
-      suppressHydrationWarning
-      className={`${inter.variable} ${jetbrainsMono.variable} ${generalFontClass} ${codeFontClass}`}
-    >
+    <html lang="en" suppressHydrationWarning className={`${generalFontClass} ${codeFontClass}`}> 
+      <head>
+        {fontPreloads.map((href) => (
+          <link
+            key={href}
+            rel="preload"
+            href={href}
+            as="font"
+            type="font/woff2"
+            crossOrigin="anonymous"
+          />
+        ))}
+      </head>
       <body suppressHydrationWarning={true} className="antialiased">
         <Providers>
           {children}

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -10,7 +10,7 @@ import { Link } from 'react-router';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 import { useUIStore } from '@/frontend/stores/uiStore';
 import { useScrollHide } from '@/frontend/hooks/useScrollHide';
-import { motion } from 'framer-motion';
+import { motion, type Transition } from 'framer-motion';
 // additional imports from previous version
 import { UIMessage } from 'ai';
 import { v4 as uuidv4 } from 'uuid';
@@ -105,7 +105,7 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
     hiddenRight: { opacity: 0, x: '110%' },
     partialRight: { x: '48px' },
   } as const;
-  const transition = { duration: 0.3, ease: 'easeInOut' };
+  const transition: Transition = { duration: 0.3, ease: 'easeInOut' };
 
   return (
     <div className="w-full h-screen flex flex-col overflow-hidden">

--- a/frontend/stores/SettingsStore.ts
+++ b/frontend/stores/SettingsStore.ts
@@ -2,8 +2,8 @@ import { create, Mutate, StoreApi } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 // Available fonts presented in the settings UI
-export const GENERAL_FONTS = ['Inter', 'System Font'] as const;
-export const CODE_FONTS = ['JetBrains Mono', 'System Monospace Font'] as const;
+export const GENERAL_FONTS = ['Proxima Vara', 'System Font'] as const;
+export const CODE_FONTS = ['Berkeley Mono', 'System Monospace Font'] as const;
 export const THEMES = ['light', 'dark'] as const;
 
 export type GeneralFont = (typeof GENERAL_FONTS)[number];
@@ -42,10 +42,10 @@ export const withStorageDOMEvents = (store: StoreWithPersist) => {
 };
 
 const defaultSettings: Settings = {
-  // Default interface font uses Inter for broad language support
-  generalFont: 'Inter',
-  // Code font uses JetBrains Mono for improved readability
-  codeFont: 'JetBrains Mono',
+  // Default interface font
+  generalFont: 'Proxima Vara',
+  // Default code font
+  codeFont: 'Berkeley Mono',
   theme: 'light',
 };
 


### PR DESCRIPTION
## Summary
- add preload list for custom fonts
- inject preloads in RootLayout and read font cookie on SSR
- define font faces and CSS vars for Proxima Vara and Berkeley Mono
- update font choices in settings store
- fix build issue with transition typing

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684ca9d168e8832baeffe66d028a4a8a