### PR TITLE
Fix build issues with proper typings

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -11,7 +11,7 @@ import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 import { cn } from '@/lib/utils';
 import { useUIStore } from '@/frontend/stores/uiStore';
 import { useScrollHide } from '@/frontend/hooks/useScrollHide';
-import { motion, type Transition } from 'framer-motion';
+import { motion, type Transition, easeInOut } from 'framer-motion';
 // additional imports from previous version
 import { UIMessage } from 'ai';
 import { v4 as uuidv4 } from 'uuid';
@@ -107,7 +107,7 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
     hiddenRight: { opacity: 0, x: '110%' },
     fade: { opacity: 0, x: 0 }, // fades out without horizontal shift
   } as const;
-  const transition: Transition = { duration: 0.3, ease: 'easeInOut' };
+  const transition: Transition = { duration: 0.3, ease: easeInOut };
 
   return (
     <div className={cn(

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.6",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@types/react-test-renderer": "^19.1.0",
     "@welldone-software/why-did-you-render": "^10.0.1",
     "eslint": "^9.28.0",
     "eslint-config-next": "15.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
+      '@types/react-test-renderer':
+        specifier: ^19.1.0
+        version: 19.1.0
       '@welldone-software/why-did-you-render':
         specifier: ^10.0.1
         version: 10.0.1(react@19.1.0)
@@ -2188,6 +2191,9 @@ packages:
 
   '@types/react-syntax-highlighter@15.5.13':
     resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
+
+  '@types/react-test-renderer@19.1.0':
+    resolution: {integrity: sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==}
 
   '@types/react@19.1.6':
     resolution: {integrity: sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==}
@@ -7546,6 +7552,10 @@ snapshots:
       '@types/react': 19.1.6
 
   '@types/react-syntax-highlighter@15.5.13':
+    dependencies:
+      '@types/react': 19.1.6
+
+  '@types/react-test-renderer@19.1.0':
     dependencies:
       '@types/react': 19.1.6
 

--- a/scripts/profiling.ts
+++ b/scripts/profiling.ts
@@ -9,8 +9,14 @@ const renderCounts: Record<string, number> = {};
 
 whyDidYouRender(React, {
   trackAllPureComponents: true,
-  notifier: ({ Component }) => {
-    const name = (Component.displayName || Component.name || 'Unknown') as string;
+  notifier: ({ Component, displayName }) => {
+    // displayName is provided by why-did-you-render typings, but fall back to
+    // component metadata when unavailable.
+    const name =
+      displayName ||
+      (Component as any).displayName ||
+      (Component as any).name ||
+      'Unknown';
     renderCounts[name] = (renderCounts[name] || 0) + 1;
   },
 });


### PR DESCRIPTION
## Summary
- add `@types/react-test-renderer` as a dev dependency
- use `easeInOut` constant from framer-motion for transition
- update profiler script to safely read display names

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684caf7f3394832b9a65ee3ad18e244c