### PR TITLE
Fix memo usage and optimize stores

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useChat } from '@ai-sdk/react';
+import { memo } from 'react';
 import Messages from './Messages';
 import ChatInput from './ChatInput';
 import ChatHistoryButton from './ChatHistoryButton';
@@ -10,7 +11,7 @@ import { Link } from 'react-router';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 import { cn } from '@/lib/utils';
 import { useUIStore } from '@/frontend/stores/uiStore';
-import { useScrollHide } from '@/frontend/hooks/useScrollHide';
+import { useScrollHideRef } from '@/frontend/hooks/useScrollHide';
 import { motion, type Transition, easeInOut } from 'framer-motion';
 // additional imports from previous version
 import { UIMessage } from 'ai';
@@ -28,14 +29,14 @@ interface ChatProps {
   initialMessages: UIMessage[];
 }
 
-export default function Chat({ threadId, initialMessages }: ChatProps) {
+function ChatComponent({ threadId, initialMessages }: ChatProps) {
   // existing hooks
-  const { keys } = useAPIKeyStore();
+  const keys = useAPIKeyStore((state) => state.keys);
   const { selectedModel } = useModelStore();
   const { isMobile } = useIsMobile();
-  const scrollHidden = useScrollHide();
+  const scrollHiddenRef = useScrollHideRef();
   const isEditing = useUIStore((state) => !!state.editingMessageId);
-  const shouldHideHeader = scrollHidden || isEditing;
+  const shouldHideHeader = scrollHiddenRef.current || isEditing;
   const { id } = useParams();
   const hasKeys = useAPIKeyStore((state) => state.hasRequiredKeys());
 
@@ -176,3 +177,7 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
     </div>
   );
 }
+
+const Chat = memo(ChatComponent);
+
+export default Chat;

--- a/frontend/components/ChatHistoryButton.tsx
+++ b/frontend/components/ChatHistoryButton.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from 'react';
+import { useState, memo } from 'react';
 import { Button } from './ui/button';
 import { History } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
@@ -13,10 +13,10 @@ interface ChatHistoryButtonProps {
   size?: "default" | "sm" | "lg" | "icon";
 }
 
-export default function ChatHistoryButton({ 
-  className, 
-  variant = "outline", 
-  size = "icon" 
+function ChatHistoryButtonComponent({
+  className,
+  variant = "outline",
+  size = "icon"
 }: ChatHistoryButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -40,4 +40,6 @@ export default function ChatHistoryButton({
       </Tooltip>
     </ChatHistoryDrawer>
   );
-} 
+}
+
+export default memo(ChatHistoryButtonComponent);

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -69,7 +69,8 @@ function PureChatInput({
 }: ChatInputProps) {
   const canChat = useAPIKeyStore((state) => state.hasRequiredKeys());
   const { currentQuote, clearQuote } = useQuoteStore();
-  const { keys, setKeys } = useAPIKeyStore();
+  const keys = useAPIKeyStore((s) => s.keys);
+  const setKeys = useAPIKeyStore((s) => s.setKeys);
   const [localKeys, setLocalKeys] = useState(keys);
   const saveKeys = () => { setKeys(localKeys); toast.success('API keys saved'); };
 

--- a/frontend/components/ChatNavigationBars.tsx
+++ b/frontend/components/ChatNavigationBars.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { useState } from "react"
+import { useState, memo } from "react"
 import { cn } from "@/lib/utils"
 import { UIMessage } from 'ai'
 
@@ -10,7 +10,7 @@ interface ChatNavigationBarsProps {
   scrollToMessage: (id: string) => void
 }
 
-export default function ChatNavigationBars({ messages, scrollToMessage }: ChatNavigationBarsProps) {
+function ChatNavigationBarsComponent({ messages, scrollToMessage }: ChatNavigationBarsProps) {
   const [hoveredBar, setHoveredBar] = useState<string | null>(null)
 
   // Фильтруем только пользовательские сообщения для навигации
@@ -93,3 +93,5 @@ export default function ChatNavigationBars({ messages, scrollToMessage }: ChatNa
     </div>
   )
 }
+
+export default memo(ChatNavigationBarsComponent)

--- a/frontend/components/KeyPrompt.tsx
+++ b/frontend/components/KeyPrompt.tsx
@@ -1,8 +1,9 @@
 import { Button } from '@/frontend/components/ui/button';
 import { Key } from 'lucide-react';
 import { Link } from 'react-router';
+import { memo } from 'react';
 
-export default function KeyPrompt() {
+function KeyPromptComponent() {
   return (
     <div className="fixed bottom-6 left-1/2 z-50">
       <div className="flex items-center p-4 pr-5 border rounded-lg bg-background shadow-lg gap-4 max-w-md">
@@ -26,3 +27,5 @@ export default function KeyPrompt() {
     </div>
   );
 }
+
+export default memo(KeyPromptComponent);

--- a/frontend/components/NewChatButton.tsx
+++ b/frontend/components/NewChatButton.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Link } from 'react-router';
+import { memo } from 'react';
 import { Button } from './ui/button';
 import { Plus } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
@@ -12,10 +13,10 @@ interface NewChatButtonProps {
   size?: "default" | "sm" | "lg" | "icon";
 }
 
-export default function NewChatButton({ 
-  className, 
-  variant = "outline", 
-  size = "icon" 
+function NewChatButtonComponent({
+  className,
+  variant = "outline",
+  size = "icon"
 }: NewChatButtonProps) {
   return (
     <Tooltip>
@@ -36,4 +37,6 @@ export default function NewChatButton({
       </TooltipContent>
     </Tooltip>
   );
-} 
+}
+
+export default memo(NewChatButtonComponent);

--- a/frontend/components/SettingsDrawer.tsx
+++ b/frontend/components/SettingsDrawer.tsx
@@ -164,7 +164,8 @@ export default function SettingsDrawer({ children, isOpen, setIsOpen }: Settings
 }
 
 const CustomizationTab = () => {
-  const { settings, setSettings } = useSettingsStore();
+  const settings = useSettingsStore((s) => s.settings);
+  const setSettings = useSettingsStore((s) => s.setSettings);
   const { setTheme } = useTheme();
 
   const handleFontChange = (type: 'generalFont' | 'codeFont', value: GeneralFont | CodeFont) => {
@@ -384,7 +385,8 @@ const ProfileTab = () => {
 };
 
 const APIKeysTab = () => {
-  const { keys, setKeys } = useAPIKeyStore();
+  const keys = useAPIKeyStore((s) => s.keys);
+  const setKeys = useAPIKeyStore((s) => s.setKeys);
 
   const {
     register,

--- a/frontend/stores/APIKeyStore.ts
+++ b/frontend/stores/APIKeyStore.ts
@@ -63,4 +63,6 @@ export const useAPIKeyStore = create<APIKeyStore>()(
   )
 );
 
-withStorageDOMEvents(useAPIKeyStore);
+if (typeof window !== 'undefined') {
+  withStorageDOMEvents(useAPIKeyStore);
+}

--- a/frontend/stores/ModelStore.ts
+++ b/frontend/stores/ModelStore.ts
@@ -48,4 +48,6 @@ export const useModelStore = create<ModelStore>()(
   )
 );
 
-withStorageDOMEvents(useModelStore);
+if (typeof window !== 'undefined') {
+  withStorageDOMEvents(useModelStore);
+}


### PR DESCRIPTION
## Summary
- memoize buttons and navigation components
- move scroll effect logic to a ref
- use selectors when reading settings and API keys
- guard DOM-related store helpers for SSR
- memoize main Chat component

## Testing
- `pnpm lint`
- `pnpm run profiling` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684cb1f14c94832bacc2658b98543f1b