### PR TITLE
Fix overscroll and improve scroll button

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -232,6 +232,7 @@ html, body {
     @apply border-border outline-ring/50;
   }
   body {
+    overscroll-behavior: contain;
     font-family: var(--font-sans);
     @apply bg-background text-foreground;
   }

--- a/frontend/components/ScrollToBottomButton.tsx
+++ b/frontend/components/ScrollToBottomButton.tsx
@@ -18,24 +18,26 @@ export default function ScrollToBottomButton({
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
+    // document.scrollingElement accounts for browsers that scroll <body>
+    const scrollEl = document.scrollingElement ?? document.documentElement;
     const handleScroll = () => {
-      const scrollTop = window.scrollY;
-      const innerHeight = window.innerHeight;
-      const scrollHeight = document.documentElement.scrollHeight;
-      setIsVisible(scrollTop + innerHeight < scrollHeight - threshold);
+      const { scrollTop, clientHeight, scrollHeight } = scrollEl;
+      setIsVisible(scrollTop + clientHeight < scrollHeight - threshold);
     };
 
-    window.addEventListener('scroll', handleScroll);
+    // Listen on document to track the actual scrolling element
+    document.addEventListener('scroll', handleScroll, { passive: true });
     handleScroll();
-    
+
     return () => {
-      window.removeEventListener('scroll', handleScroll);
+      document.removeEventListener('scroll', handleScroll);
     };
   }, [threshold]);
 
   const scrollToBottom = () => {
-    window.scrollTo({
-      top: document.documentElement.scrollHeight,
+    const scrollEl = document.scrollingElement ?? document.documentElement;
+    scrollEl.scrollTo({
+      top: scrollEl.scrollHeight,
       behavior: 'smooth',
     });
   };


### PR DESCRIPTION
## Summary
- prevent bounce scroll on mobile by containing body overscroll
- use `document.scrollingElement` for scroll-to-bottom button
- avoid nested scroll container on mobile

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684cb20e93c4832b9df4bf6471e6f98b