### PR TITLE
Fix scrollHiddenRef usage in Chat component

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -139,7 +139,7 @@ function ChatComponent({ threadId, initialMessages }: ChatProps) {
               animate={
                 isMobile && isEditing
                   ? 'hiddenRight'
-                  : isMobile && scrollHidden
+                  : isMobile && scrollHiddenRef.current
                     ? 'fade'
                     : 'visible'
               }


### PR DESCRIPTION
## Summary
- fix Chat header animation logic by referencing `scrollHiddenRef.current`

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684cb5573fb0832b83566851812994af