### PR TITLE
fix: prevent mobile white gap

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -60,9 +60,10 @@
   font-display: swap;
 }
 
-/* Prevent horizontal scrollbars */
+/* Prevent horizontal scrollbars and enforce viewport height */
 html, body {
   max-width: 100%;
+  min-height: 100dvh;
   overflow-x: hidden;
 }
 
@@ -233,6 +234,8 @@ html, body {
   }
   body {
     overscroll-behavior: contain;
+    overscroll-behavior-y: none;
+    background: var(--bg);
     font-family: var(--font-sans);
     @apply bg-background text-foreground;
   }


### PR DESCRIPTION
## Summary
- enforce `min-height:100dvh` for html/body
- add overscroll and background fixes for body

## Testing
- `pnpm dev` *(fails: Terminated)*
- `pnpm typecheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cbf922868832b842c6f5758586f49