### PR TITLE
fix: mobile header slide animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -380,6 +380,11 @@ html, body {
     overscroll-behavior: contain;
     scroll-behavior: smooth;
   }
+
+  /* Prevent scroll chaining in mobile chat */
+  .mobile-chat-scroll {
+    overscroll-behavior: contain;
+  }
   
   /* Дополнительные отступы для мобильных настроек */
   .mobile-settings-content {

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -179,6 +179,7 @@ function PureChatInput({
           messageCount === 0 &&
             'md:bottom-auto md:top-1/2 md:transform md:-translate-y-1/2'
         )}
+        style={{ height: CHAT_INPUT_HEIGHT }}
       >
         <div ref={containerRef} className={cn('relative bg-secondary p-2 pb-0 w-full', messageCount === 0 ? 'rounded-[20px]' : 'rounded-t-[20px]')}>
           {/* Scroll to bottom button */}
@@ -365,3 +366,6 @@ const SendButton = memo(PureSendButton, (prevProps, nextProps) => {
 });
 
 export default ChatInput;
+
+// Height of the fixed chat input in pixels. Used to offset chat padding.
+export const CHAT_INPUT_HEIGHT = 72; // px

--- a/frontend/components/Messages.tsx
+++ b/frontend/components/Messages.tsx
@@ -9,6 +9,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { useAutoHide } from '../hooks/useAutoHide';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 import { cn } from '@/lib/utils';
+import { CHAT_INPUT_HEIGHT } from './ChatInput';
 
 /** Постоянная оценка высоты одного сообщения для виртуализатора. */
 const ESTIMATED_MESSAGE_HEIGHT = 200;
@@ -80,8 +81,10 @@ function PureMessages({
       ref={parentRef}
       className={cn(
         'flex flex-col space-y-12 h-full',
-        !isMobile && 'overflow-y-auto'
+        !isMobile && 'overflow-y-auto',
+        isMobile && 'mobile-chat-scroll'
       )}
+      style={{ paddingBottom: CHAT_INPUT_HEIGHT }}
     >
       {shouldVirtualize ? (
         /* «Плёнка» с абсолютным позиционированием виртуальных строк */


### PR DESCRIPTION
## Summary
- set constant CHAT_INPUT_HEIGHT and use it for ChatInput height
- pad Messages list so content isn't hidden beneath ChatInput on mobile
- prevent scroll chaining via `mobile-chat-scroll`

## Testing
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `pnpm lint`
- `pnpm dev` *(started Next.js dev server)*

------
https://chatgpt.com/codex/tasks/task_e_684cbf65fae8832b92ecdbdff2be6aa9