### PR TITLE
Integrate frontend with Convex backend

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -17,6 +17,9 @@ import { Link } from 'react-router';
 import { cn } from '@/lib/utils';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Id } from '@/convex/_generated/dataModel';
 
 interface ChatProps {
   threadId: string;
@@ -29,6 +32,7 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
   const { isMobile } = useIsMobile();
   const isHeaderVisible = useScrollHide({ threshold: 15 });
   const { id } = useParams();
+  const sendMessage = useMutation(api.messages.send);
   const hasKeys = useAPIKeyStore(state => state.hasRequiredKeys());
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
 
@@ -86,8 +90,11 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
           }
         ],
       };
-      
-      // TODO: save message to Convex
+      await sendMessage({
+        threadId: threadId as Id<'threads'>,
+        role: 'assistant',
+        content: message.content,
+      });
     },
   });
 

--- a/frontend/routes/Thread.tsx
+++ b/frontend/routes/Thread.tsx
@@ -1,15 +1,25 @@
 import Chat from '@/frontend/components/Chat';
 import { useParams } from 'react-router';
-// Dexie imports removed; messages will be loaded from server later
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Id } from '@/convex/_generated/dataModel';
 import { UIMessage } from 'ai';
 
 export default function Thread() {
   const { id } = useParams();
   if (!id) throw new Error('Thread ID is required');
 
-  const messages: UIMessage[] = [];
+  const threadId = id as Id<'threads'>;
+  const messages = useQuery(api.messages.get, { threadId });
 
-  return (
-    <Chat key={id} threadId={id} initialMessages={messages} />
-  );
+  const uiMessages: UIMessage[] =
+    messages?.map(msg => ({
+      id: msg._id,
+      role: msg.role,
+      content: msg.content,
+      createdAt: new Date(msg._creationTime),
+      parts: [{ type: 'text', text: msg.content }],
+    })) || [];
+
+  return <Chat key={id} threadId={threadId} initialMessages={uiMessages} />;
 }


### PR DESCRIPTION
## Summary
- hook chat history drawer up to Convex queries/mutations
- load thread messages from Convex
- send messages via Convex from chat and chat input components

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684d6fb140b0832baa8c5d4f161c994e