### PR TITLE
Fix user sync to wait for auth

### DIFF
--- a/frontend/hooks/useUserSync.ts
+++ b/frontend/hooks/useUserSync.ts
@@ -1,17 +1,16 @@
 import { useEffect } from 'react';
-import { useMutation } from 'convex/react';
+import { useMutation, useConvexAuth } from 'convex/react';
 import { api } from '@/convex/_generated/api';
-import { useAuthStore } from '@/frontend/stores/AuthStore';
 
 export function useUserSync() {
-  const { user } = useAuthStore();
+  const { isAuthenticated, isLoading } = useConvexAuth();
   const syncUser = useMutation(api.users.sync);
 
   useEffect(() => {
-    if (user) {
+    if (!isLoading && isAuthenticated) {
       syncUser().catch(error => {
         console.error('Failed to sync user:', error);
       });
     }
-  }, [user, syncUser]);
-} 
+  }, [isAuthenticated, isLoading, syncUser]);
+}


### PR DESCRIPTION
## Summary
- use `useConvexAuth` in `useUserSync` to ensure auth token is ready before syncing

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684dacb2282c832ba48af40d8d12c449