### PR TITLE
Fix Firebase token refresh loops

### DIFF
--- a/frontend/components/AuthListener.tsx
+++ b/frontend/components/AuthListener.tsx
@@ -1,10 +1,12 @@
 'use client';
 import { useAuthStore } from '@/frontend/stores/AuthStore';
+import { useEffect } from 'react';
 
 export default function AuthListener() {
-  // Этот хук просто вызывает useAuthStore и тем самым
-  // инициализирует его логику, включая onAuthStateChanged.
-  // Он ничего не рендерит.
-  useAuthStore(); 
+  const init = useAuthStore((s) => s.init);
+
+  // Start Firebase auth listener on mount and clean up on unmount
+  useEffect(() => init(), [init]);
+
   return null;
-} 
+}

--- a/frontend/components/ConvexClientProvider.tsx
+++ b/frontend/components/ConvexClientProvider.tsx
@@ -1,55 +1,74 @@
 "use client";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect, useState, useMemo, useCallback, useRef } from "react";
 import { ConvexProviderWithAuth, ConvexReactClient } from "convex/react";
 import { useAuthStore } from "@/frontend/stores/AuthStore";
 import { auth } from "@/firebase";
+import { onIdTokenChanged } from "firebase/auth";
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 export default function ConvexClientProvider({ children }: { children: ReactNode }) {
   const { user, loading } = useAuthStore();
   const [idToken, setIdToken] = useState<string | null | undefined>(undefined);
+  const cachedToken = useRef<string>();
+  const cachedExp = useRef<number>(0); // ms timestamp when cached token expires
 
   useEffect(() => {
-    if (loading) return;
-    
     if (!user) {
       setIdToken(null);
+      cachedToken.current = undefined;
+      cachedExp.current = 0;
       return;
     }
-    
-    const getIdToken = async () => {
-      try {
-        const token = await user.getIdToken();
-        setIdToken(token || null);
-      } catch (error) {
-        console.error("Failed to get id token:", error);
-        setIdToken(null);
-      }
-    };
-    getIdToken();
-  }, [user, loading]);
 
-  return (
-    <ConvexProviderWithAuth client={convex} useAuth={(() => ({
+    // Reactively update token when Firebase refreshes it
+    const unsub = onIdTokenChanged(auth, async (u) => {
+      if (!u) {
+        setIdToken(null);
+        cachedToken.current = undefined;
+        cachedExp.current = 0;
+        return;
+      }
+
+      const token = await u.getIdToken();
+      setIdToken(token);
+      cachedToken.current = token;
+      cachedExp.current = u.stsTokenManager.expirationTime!;
+    });
+
+    return unsub;
+  }, [user]);
+
+  // Get ID token, refreshing only when requested or expired
+  const getFreshToken = useCallback(
+    async (force = false) => {
+      if (!user) return "";
+      if (!force && cachedToken.current && Date.now() < cachedExp.current - 60_000) {
+        // token is still valid for at least a minute
+        return cachedToken.current;
+      }
+
+      const t = await user.getIdToken(force);
+      cachedToken.current = t;
+      cachedExp.current = user.stsTokenManager.expirationTime!;
+      return t;
+    },
+    [user]
+  );
+
+  const authState = useMemo(
+    () => ({
       isLoading: idToken === undefined || loading,
       isAuthenticated: !!idToken,
-      fetchAccessToken: async ({ forceRefreshToken }) => {
-        if (!user) return "";
-        
-        try {
-          const newToken = await user.getIdToken(forceRefreshToken);
-          if (forceRefreshToken) {
-            setIdToken(newToken);
-          }
-          return newToken || "";
-        } catch (error) {
-          console.error("Failed to get access token:", error);
-          return "";
-        }
-      }
-    }))}>
+      fetchAccessToken: async ({ forceRefreshToken }: { forceRefreshToken: boolean }) =>
+        getFreshToken(forceRefreshToken),
+    }),
+    [idToken, loading, getFreshToken]
+  );
+
+  return (
+    <ConvexProviderWithAuth client={convex} useAuth={() => authState}>
       {children}
     </ConvexProviderWithAuth>
   );
-} 
+}

--- a/frontend/stores/AuthStore.ts
+++ b/frontend/stores/AuthStore.ts
@@ -9,6 +9,7 @@ interface AuthState {
   login: () => Promise<void>;
   logout: () => Promise<void>;
   toggleBlur: () => void;
+  init: () => () => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => {
@@ -33,12 +34,16 @@ export const useAuthStore = create<AuthState>((set) => {
     },
   };
 
-  // 2. Слушатель состояния Firebase
-  if (typeof window !== 'undefined') {
-    onAuthStateChanged(auth, async (user) => {
+  // Allows React components to start and clean up the auth listener
+  const init = () => {
+    if (typeof window === 'undefined') {
+      return () => {};
+    }
+    const unsub = onAuthStateChanged(auth, async (user) => {
       set({ user, loading: false });
     });
-  }
+    return unsub;
+  };
 
   // 3. Начальное состояние + действия
   return {
@@ -46,5 +51,6 @@ export const useAuthStore = create<AuthState>((set) => {
     loading: true,
     blurPersonalData: false,
     ...actions,
+    init,
   };
-}); 
+});


### PR DESCRIPTION
## Summary
- stabilize Convex auth provider by caching tokens
- refresh tokens via Firebase onIdTokenChanged
- provide init cleanup for auth listener

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684dc15751a8832bba2f1c865b2e3fbd