### PR TITLE
Fix nested buttons and API key handling

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -14,6 +14,12 @@ export async function POST(req: NextRequest) {
     const modelConfig = getModelConfig(model as AIModel);
 
     const apiKey = apiKeys[modelConfig.provider];
+    if (!apiKey) {
+      return new NextResponse(
+        JSON.stringify({ error: 'Missing API key' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
 
     let aiModel;
     switch (modelConfig.provider) {

--- a/eslint-rules/no-nested-interactive.js
+++ b/eslint-rules/no-nested-interactive.js
@@ -1,0 +1,31 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow nesting interactive elements',
+    },
+    schema: [],
+  },
+  create(context) {
+    function containsButton(children) {
+      return children.some((child) => {
+        if (child.type === 'JSXElement') {
+          if (child.openingElement.name.name === 'button') {
+            return true;
+          }
+          return containsButton(child.children);
+        }
+        return false;
+      });
+    }
+
+    return {
+      JSXElement(node) {
+        if (node.openingElement.name.name !== 'button') return;
+        if (containsButton(node.children)) {
+          context.report({ node, message: 'Nested button elements are not allowed.' });
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,13 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import noNestedInteractive from "./eslint-rules/no-nested-interactive.js";
+
+const customPlugin = {
+  rules: {
+    'no-nested-interactive': noNestedInteractive,
+  },
+};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -10,7 +17,18 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends(
+    "next/core-web-vitals",
+    "next/typescript",
+    "plugin:jsx-a11y/recommended"
+  ),
+  {
+    plugins: { custom: customPlugin },
+    rules: {
+      "jsx-a11y/no-noninteractive-element-interactions": "error",
+      "custom/no-nested-interactive": "error",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/frontend/ChatLayout.tsx
+++ b/frontend/ChatLayout.tsx
@@ -1,9 +1,12 @@
 import { Outlet } from 'react-router';
+import ErrorBoundary from './components/ErrorBoundary';
 
 export default function ChatLayout() {
   return (
-    <div className="w-full h-full">
-      <Outlet />
-    </div>
+    <ErrorBoundary>
+      <div className="w-full h-full">
+        <Outlet />
+      </div>
+    </ErrorBoundary>
   );
 }

--- a/frontend/components/ChatHistoryButton.tsx
+++ b/frontend/components/ChatHistoryButton.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Button } from './ui/button';
 import { History } from 'lucide-react';
-import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+import { WithTooltip } from './WithTooltip';
 import ChatHistoryDrawer from './ChatHistoryDrawer';
 import { cn } from '@/lib/utils';
 
@@ -22,22 +22,17 @@ export default function ChatHistoryButton({
 
   return (
     <ChatHistoryDrawer isOpen={isOpen} setIsOpen={setIsOpen}>
-      <Tooltip>
-        <TooltipTrigger>
-          <Button
-            variant={variant}
-            size={size}
-            className={cn("bg-background/80 backdrop-blur-sm border-border/50", className)}
-            aria-label="Open chat history"
-            onClick={() => setIsOpen(true)}
-          >
-            <History className="h-5 w-5" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          History
-        </TooltipContent>
-      </Tooltip>
+      <WithTooltip label="History" side="bottom">
+        <Button
+          variant={variant}
+          size={size}
+          className={cn('bg-background/80 backdrop-blur-sm border-border/50', className)}
+          aria-label="Open chat history"
+          onClick={() => setIsOpen(true)}
+        >
+          <History className="h-5 w-5" />
+        </Button>
+      </WithTooltip>
     </ChatHistoryDrawer>
   );
 } 

--- a/frontend/components/ErrorBoundary.tsx
+++ b/frontend/components/ErrorBoundary.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Error from './Error';
+
+type Props = { children: React.ReactNode };
+
+type State = { error: Error | null };
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return <Error message={this.state.error.message} />;
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/components/NewChatButton.tsx
+++ b/frontend/components/NewChatButton.tsx
@@ -3,7 +3,7 @@
 import { useNavigate } from 'react-router';
 import { Button } from './ui/button';
 import { Plus } from 'lucide-react';
-import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+import { WithTooltip } from './WithTooltip';
 import { cn } from '@/lib/utils';
 
 interface NewChatButtonProps {
@@ -24,21 +24,16 @@ export default function NewChatButton({
   };
 
   return (
-    <Tooltip>
-      <TooltipTrigger>
-        <Button
-          variant={variant}
-          size={size}
-          className={cn("bg-background/80 backdrop-blur-sm border-border/50", className)}
-          aria-label="Create new chat"
-          onClick={handleClick}
-        >
-          <Plus className="h-5 w-5" />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">
-        New Chat
-      </TooltipContent>
-    </Tooltip>
+    <WithTooltip label="New Chat" side="bottom">
+      <Button
+        variant={variant}
+        size={size}
+        className={cn('bg-background/80 backdrop-blur-sm border-border/50', className)}
+        aria-label="Create new chat"
+        onClick={handleClick}
+      >
+        <Plus className="h-5 w-5" />
+      </Button>
+    </WithTooltip>
   );
 } 

--- a/frontend/components/SettingsButton.tsx
+++ b/frontend/components/SettingsButton.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Button } from './ui/button';
 import { Settings } from 'lucide-react';
-import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+import { WithTooltip } from './WithTooltip';
 import SettingsDrawer from './SettingsDrawer';
 import { cn } from '@/lib/utils';
 
@@ -22,22 +22,17 @@ export default function SettingsButton({
 
   return (
     <SettingsDrawer isOpen={isOpen} setIsOpen={setIsOpen}>
-      <Tooltip>
-        <TooltipTrigger>
-          <Button
-            variant={variant}
-            size={size}
-            className={cn("bg-background/80 backdrop-blur-sm border-border/50", className)}
-            aria-label="Open settings"
-            onClick={() => setIsOpen(true)}
-          >
-            <Settings className="h-5 w-5" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          Settings
-        </TooltipContent>
-      </Tooltip>
+      <WithTooltip label="Settings" side="bottom">
+        <Button
+          variant={variant}
+          size={size}
+          className={cn('bg-background/80 backdrop-blur-sm border-border/50', className)}
+          aria-label="Open settings"
+          onClick={() => setIsOpen(true)}
+        >
+          <Settings className="h-5 w-5" />
+        </Button>
+      </WithTooltip>
     </SettingsDrawer>
   );
 } 

--- a/frontend/components/WithTooltip.tsx
+++ b/frontend/components/WithTooltip.tsx
@@ -1,0 +1,17 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+import React from 'react';
+
+interface WithTooltipProps {
+  label: string;
+  children: React.ReactElement;
+  side?: React.ComponentProps<typeof TooltipContent>['side'];
+}
+
+export function WithTooltip({ label, children, side = 'top' }: WithTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side={side}>{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/frontend/routes/Settings.tsx
+++ b/frontend/routes/Settings.tsx
@@ -3,6 +3,7 @@ import { buttonVariants } from '../components/ui/button';
 import { ArrowLeftIcon } from 'lucide-react';
 import SettingsDrawer from '@/frontend/components/SettingsDrawer';
 import { useState } from 'react';
+import ErrorBoundary from '@/frontend/components/ErrorBoundary';
 
 export default function Settings() {
   const [searchParams] = useSearchParams();
@@ -10,24 +11,26 @@ export default function Settings() {
   const [isOpen, setIsOpen] = useState(true);
 
   return (
-    <section className="flex w-full h-full">
-      <Link
-        to={{
-          pathname: `/chat${chatId ? `/${chatId}` : ''}`,
-        }}
-        className={buttonVariants({
-          variant: 'default',
-          className: 'w-fit fixed top-10 left-40 z-10',
-        })}
-      >
-        <ArrowLeftIcon className="w-4 h-4" />
-        Back to Chat
-      </Link>
-      <div className="flex items-center justify-center w-full h-full pt-24 pb-44 mx-auto">
-        <SettingsDrawer isOpen={isOpen} setIsOpen={setIsOpen}>
-          <div />
-        </SettingsDrawer>
-      </div>
-    </section>
+    <ErrorBoundary>
+      <section className="flex w-full h-full">
+        <Link
+          to={{
+            pathname: `/chat${chatId ? `/${chatId}` : ''}`,
+          }}
+          className={buttonVariants({
+            variant: 'default',
+            className: 'w-fit fixed top-10 left-40 z-10',
+          })}
+        >
+          <ArrowLeftIcon className="w-4 h-4" />
+          Back to Chat
+        </Link>
+        <div className="flex items-center justify-center w-full h-full pt-24 pb-44 mx-auto">
+          <SettingsDrawer isOpen={isOpen} setIsOpen={setIsOpen}>
+            <div />
+          </SettingsDrawer>
+        </div>
+      </section>
+    </ErrorBoundary>
   );
 }

--- a/frontend/routes/Thread.tsx
+++ b/frontend/routes/Thread.tsx
@@ -4,6 +4,7 @@ import { useQuery, useConvexAuth } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
 import { UIMessage } from 'ai';
+import ErrorBoundary from '@/frontend/components/ErrorBoundary';
 
 export default function Thread() {
   const { id } = useParams();
@@ -49,5 +50,9 @@ export default function Thread() {
     parts: [{ type: 'text', text: msg.content }],
   }));
 
-  return <Chat key={id} threadId={threadId} initialMessages={uiMessages} />;
+  return (
+    <ErrorBoundary>
+      <Chat key={id} threadId={threadId} initialMessages={uiMessages} />
+    </ErrorBoundary>
+  );
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "eslint": "^9.28.0",
     "eslint-config-next": "15.3.2",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
     "tailwindcss": "^4.1.8",
     "tw-animate-css": "^1.3.4",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       eslint-config-next:
         specifier: 15.3.2
         version: 15.3.2(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.8.0
+        version: 6.10.2(eslint@9.28.0(jiti@2.4.2))
       tailwindcss:
         specifier: ^4.1.8
         version: 4.1.8


### PR DESCRIPTION
## Summary
- add `WithTooltip` to ensure `asChild` usage for tooltips
- use `WithTooltip` in various buttons
- validate API keys in `chat` API route
- add `ErrorBoundary` and wrap pages
- enforce custom ESLint rule against nested interactive elements

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_684dd76a4d04832ba4019566771fdaa0