### PR TITLE
Fix crashes and optimize chat UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -391,3 +391,12 @@
 .blur-md {
     filter: blur(8px);
 }
+
+@keyframes fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.fade-in {
+  animation: fade .2s ease-in;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,8 @@ import './globals.css';
 import 'katex/dist/katex.min.css';
 import { Toaster } from '@/frontend/components/ui/sonner';
 import Providers from '@/frontend/components/Providers';
+import AppShellSkeleton from '@/frontend/components/AppShellSkeleton';
+import { Suspense } from 'react';
 import AuthListener from '@/frontend/components/AuthListener';
 import ConvexClientProvider from '@/frontend/components/ConvexClientProvider';
 import UserSync from '@/frontend/components/UserSync';
@@ -41,14 +43,16 @@ export default function RootLayout({
         suppressHydrationWarning={true}
         className={`${geistSans.variable} ${geistMono.variable} antialiased font-sans`}
       >
-        <Providers>
-          <AuthListener />
-          <ConvexClientProvider>
-            <UserSync />
-            {children}
-          </ConvexClientProvider>
-          <Toaster richColors position="top-right" />
-        </Providers>
+        <Suspense fallback={<AppShellSkeleton />}>
+          <Providers>
+            <AuthListener />
+            <ConvexClientProvider>
+              <UserSync />
+              {children}
+            </ConvexClientProvider>
+            <Toaster richColors position="top-right" />
+          </Providers>
+        </Suspense>
       </body>
     </html>
   );

--- a/frontend/components/AppShellSkeleton.tsx
+++ b/frontend/components/AppShellSkeleton.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function AppShellSkeleton() {
+  return <div className="w-full h-full invisible" />;
+}

--- a/frontend/components/ChatHistoryDrawer.tsx
+++ b/frontend/components/ChatHistoryDrawer.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, memo, useDeferredValue } from 'react';
 import { Drawer, DrawerContent, DrawerTrigger, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { Dialog, DialogContent, DialogTrigger, DialogHeader, DialogTitle, DialogDescription } from '@/frontend/components/ui/dialog';
 import { Button, buttonVariants } from './ui/button';
@@ -25,8 +25,9 @@ interface ChatHistoryDrawerProps {
   setIsOpen: (open: boolean) => void;
 }
 
-export default function ChatHistoryDrawer({ children, isOpen, setIsOpen }: ChatHistoryDrawerProps) {
-  const [searchQuery, setSearchQuery] = useState('');
+function ChatHistoryDrawerComponent({ children, isOpen, setIsOpen }: ChatHistoryDrawerProps) {
+  const [raw, setRaw] = useState('');
+  const searchQuery = useDeferredValue(raw);
   const [editingThreadId, setEditingThreadId] = useState<Id<'threads'> | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
   const [deletingThreadId, setDeletingThreadId] = useState<Id<'threads'> | null>(null);
@@ -48,7 +49,7 @@ export default function ChatHistoryDrawer({ children, isOpen, setIsOpen }: ChatH
   const handleOpenChange = useCallback((open: boolean) => {
     setIsOpen(open);
     if (!open) {
-      setSearchQuery('');
+      setRaw('');
       setEditingThreadId(null);
       setEditingTitle('');
       setDeletingThreadId(null);
@@ -303,13 +304,7 @@ export default function ChatHistoryDrawer({ children, isOpen, setIsOpen }: ChatH
     return null;
   }
   
-  if (threads === undefined) {
-    return (
-      <div className="flex justify-center items-center h-full">
-        <p>Loading chat history...</p>
-      </div>
-    );
-  }
+  if (threads === undefined) return null;
 
   const ContentComponent = () => (
     <div className="flex h-full flex-col">
@@ -362,7 +357,7 @@ export default function ChatHistoryDrawer({ children, isOpen, setIsOpen }: ChatH
                 placeholder="Search…"
                 className="rounded-lg py-1.5 pl-8 text-sm w-full"
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(e) => setRaw(e.target.value)}
               />
               <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground size-3.5" />
             </div>
@@ -406,7 +401,7 @@ export default function ChatHistoryDrawer({ children, isOpen, setIsOpen }: ChatH
                     placeholder="Search…"
                     className="rounded-lg py-1.5 pl-8 text-sm w-full"
                     value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onChange={(e) => setRaw(e.target.value)}
                   />
                   <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground size-3.5" />
                 </div>
@@ -447,7 +442,7 @@ export default function ChatHistoryDrawer({ children, isOpen, setIsOpen }: ChatH
               placeholder="Search…"
               className="rounded-lg py-1.5 pl-8 text-sm w-full"
               value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
+              onChange={(e) => setRaw(e.target.value)}
             />
             <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground size-3.5" />
           </div>
@@ -458,4 +453,6 @@ export default function ChatHistoryDrawer({ children, isOpen, setIsOpen }: ChatH
       </DialogContent>
     </Dialog>
   );
-} 
+}
+
+export default memo(ChatHistoryDrawerComponent);

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -116,9 +116,9 @@ function PureChatInput({
       finalMessage = `> ${currentQuote.text.replace(/\n/g, '\n> ')}\n\n${currentInput.trim()}`;
     }
 
-    let currentThreadId = threadId;
-
-    if (!id) {
+    let currentThreadId: Id<'threads'>;
+    const isConvexId = id && !id.includes('-');
+    if (!id || !isConvexId) {
       const newThreadId = await createThread({ title: 'New Chat' });
       navigate(`/chat/${newThreadId}`);
       currentThreadId = newThreadId;
@@ -126,7 +126,8 @@ function PureChatInput({
         body: { threadId: newThreadId, messageId, isTitle: true },
       });
     } else {
-      complete(finalMessage, { body: { messageId, threadId } });
+      currentThreadId = id as Id<'threads'>;
+      complete(finalMessage, { body: { messageId, threadId: currentThreadId } });
     }
 
     const userMessage = createUserMessage(messageId, finalMessage);
@@ -171,8 +172,8 @@ function PureChatInput({
     adjustHeight();
   };
 
-  // Если есть ошибка, показываем форму для ввода API ключей
-  if (error) {
+  // Если есть ошибка и нельзя отправлять сообщения, показываем форму для ввода API ключей
+  if (error && !canChat) {
     return (
       <div className={`fixed w-full max-w-3xl bottom-0 ${messageCount === 0 ? 'md:bottom-auto md:top-1/2 md:transform md:-translate-y-1/2' : ''}`}>
         <div className={cn('bg-secondary p-4 pb-2 w-full', messageCount === 0 ? 'rounded-[20px]' : 'rounded-t-[20px]')}>

--- a/frontend/components/Message.tsx
+++ b/frontend/components/Message.tsx
@@ -6,6 +6,7 @@ import equal from 'fast-deep-equal';
 import MessageControls from './MessageControls';
 import { UseChatHelpers } from '@ai-sdk/react';
 import MessageEditor from './MessageEditor';
+import ErrorBoundary from './ErrorBoundary';
 import MessageReasoning from './MessageReasoning';
 import SelectableText from './SelectableText';
 import QuotedMessage from './QuotedMessage';
@@ -131,15 +132,17 @@ function PureMessage({
               onClick={handleMobileMessageClick}
             >
               {mode === 'edit' && (
-                <MessageEditor
-                  threadId={threadId}
-                  message={message}
-                  content={part.text}
-                  setMessages={setMessages}
-                  reload={reload}
-                  setMode={setMode}
-                  stop={stop}
-                />
+                <ErrorBoundary>
+                  <MessageEditor
+                    threadId={threadId}
+                    message={message}
+                    content={part.text}
+                    setMessages={setMessages}
+                    reload={reload}
+                    setMode={setMode}
+                    stop={stop}
+                  />
+                </ErrorBoundary>
               )}
               {mode === 'view' && <QuotedMessage content={part.text} />}
 

--- a/frontend/components/MessageEditor.tsx
+++ b/frontend/components/MessageEditor.tsx
@@ -29,7 +29,7 @@ export default function MessageEditor({
   stop: UseChatHelpers['stop'];
 }) {
   const [draftContent, setDraftContent] = useState(content);
-  const getKey = useAPIKeyStore((state) => state.getKey);
+  const { getKey } = useAPIKeyStore();
 
   const { complete } = useCompletion({
     api: '/api/completion',
@@ -105,9 +105,9 @@ export default function MessageEditor({
       setTimeout(() => {
         reload();
       }, 0);
-    } catch (error) {
-      console.error('Failed to save message:', error);
-      toast.error('Failed to save message');
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to save changes');
     }
   };
 

--- a/frontend/components/Messages.tsx
+++ b/frontend/components/Messages.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import PreviewMessage from './Message';
+import VirtualMessages from './VirtualMessages';
 import { UIMessage } from 'ai';
 import { UseChatHelpers } from '@ai-sdk/react';
 import equal from 'fast-deep-equal';
@@ -42,7 +43,7 @@ function PureMessages({
   );
 }
 
-const Messages = memo(PureMessages, (prevProps, nextProps) => {
+const PureMessagesMemo = memo(PureMessages, (prevProps, nextProps) => {
   if (prevProps.status !== nextProps.status) return false;
   if (prevProps.error !== nextProps.error) return false;
   if (prevProps.messages.length !== nextProps.messages.length) return false;
@@ -50,6 +51,14 @@ const Messages = memo(PureMessages, (prevProps, nextProps) => {
   return true;
 });
 
-Messages.displayName = 'Messages';
+PureMessagesMemo.displayName = 'Messages';
 
-export default Messages;
+const LargeListBoundary = 50;
+
+export default function Messages(props: React.ComponentProps<typeof PureMessages>) {
+  return props.messages.length > LargeListBoundary ? (
+    <VirtualMessages {...props} />
+  ) : (
+    <PureMessagesMemo {...props} />
+  );
+}

--- a/frontend/components/SettingsDrawer.tsx
+++ b/frontend/components/SettingsDrawer.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, memo } from 'react';
 import { Drawer, DrawerContent, DrawerTrigger, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { Dialog, DialogContent, DialogTrigger, DialogHeader, DialogTitle, DialogDescription } from '@/frontend/components/ui/dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -46,7 +46,7 @@ const formSchema = z.object({
 
 type FormValues = z.infer<typeof formSchema>;
 
-export default function SettingsDrawer({ children, isOpen, setIsOpen }: SettingsDrawerProps) {
+function SettingsDrawerComponent({ children, isOpen, setIsOpen }: SettingsDrawerProps) {
   const { isMobile, mounted } = useIsMobile(600);
   const [activeTab, setActiveTab] = useState("customization");
 
@@ -553,3 +553,5 @@ const ApiKeyField = ({
     )}
   </div>
 ); 
+export default memo(SettingsDrawerComponent);
+

--- a/frontend/components/VirtualMessages.tsx
+++ b/frontend/components/VirtualMessages.tsx
@@ -1,0 +1,32 @@
+import { FixedSizeList as List } from 'react-window';
+import PreviewMessage from './Message';
+import { UIMessage } from 'ai';
+import { UseChatHelpers } from '@ai-sdk/react';
+
+interface Props {
+  messages: UIMessage[];
+  threadId: string;
+  setMessages: UseChatHelpers['setMessages'];
+  reload: UseChatHelpers['reload'];
+  status: UseChatHelpers['status'];
+  error: UseChatHelpers['error'];
+  stop: UseChatHelpers['stop'];
+}
+
+export default function VirtualMessages({ messages, ...rest }: Props) {
+  const itemHeight = 240;
+  return (
+    <List
+      height={window.innerHeight}
+      itemCount={messages.length}
+      itemSize={itemHeight}
+      width="100%"
+    >
+      {({ index, style }) => (
+        <div style={style}>
+          <PreviewMessage {...rest} message={messages[index]} />
+        </div>
+      )}
+    </List>
+  );
+}

--- a/frontend/routes/Home.tsx
+++ b/frontend/routes/Home.tsx
@@ -20,7 +20,9 @@ export default function Home() {
   return (
     <>
       {!hasKeys && <KeyPrompt />}
-      <Chat threadId={uuidv4()} initialMessages={initialMessages} />
+      <div className="fade-in">
+        <Chat threadId={uuidv4()} initialMessages={initialMessages} />
+      </div>
     </>
   );
 }

--- a/frontend/routes/Thread.tsx
+++ b/frontend/routes/Thread.tsx
@@ -26,13 +26,7 @@ export default function Thread() {
     );
   }
 
-  if (messagesResult === undefined) {
-    return (
-      <div className="flex justify-center items-center h-full">
-        <p>Loading messages...</p>
-      </div>
-    );
-  }
+  if (messagesResult === undefined) return null;
 
   // Handle both array and pagination result formats
   let messages: any[] = [];
@@ -52,7 +46,9 @@ export default function Thread() {
 
   return (
     <ErrorBoundary>
-      <Chat key={id} threadId={threadId} initialMessages={uiMessages} />
+      <div className="fade-in">
+        <Chat key={id} threadId={threadId} initialMessages={uiMessages} />
+      </div>
     </ErrorBoundary>
   );
 }

--- a/frontend/stores/APIKeyStore.ts
+++ b/frontend/stores/APIKeyStore.ts
@@ -13,6 +13,10 @@ type APIKeyState = {
   keys: APIKeys;
   keysLoading: boolean;
   setLocal: (keys: Partial<APIKeys>) => void;
+  /** Возвращает ключ по имени провайдера */
+  getKey: (provider: Provider) => string | undefined;
+  /** Проверяет наличие обязательных ключей */
+  hasRequiredKeys: () => boolean;
 };
 
 // Функция для глубокого сравнения объектов
@@ -24,6 +28,8 @@ const store = create<APIKeyState>(() => ({
   keys: { google: '', openrouter: '', openai: '' },
   keysLoading: true,
   setLocal: () => {},
+  getKey: (provider: Provider) => store.getState().keys[provider],
+  hasRequiredKeys: () => !!store.getState().keys.google,
 }));
 
 export function useAPIKeyStore() {
@@ -46,9 +52,9 @@ export function useAPIKeyStore() {
   // Получаем состояние из store
   const storeState = store();
   const keysLoading = convexUser === undefined;
-  
-  // Возвращаем keys напрямую из store
-  const keys = storeState.keys;
+
+  // Возвращаем keys и утилиты из состояния
+  const { keys, getKey, hasRequiredKeys } = storeState;
   
   const setLocal = (updates: Partial<APIKeys>) => {
     const currentKeys = store.getState().keys;
@@ -107,10 +113,6 @@ export function useAPIKeyStore() {
       console.log('Keys unchanged, skipping update');
     }
   };
-
-  const hasRequiredKeys = useCallback(() =>
-    !keysLoading && !!keys.google, [keysLoading, keys.google]);
-  const getKey = useCallback((provider: Provider) => keys[provider] || null, [keys]);
 
   return { keys, setKeys, hasRequiredKeys, getKey, setLocal, keysLoading };
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-markdown": "^10.1.0",
     "react-router": "^7.6.2",
     "react-shiki": "^0.6.0",
+    "react-window": "^1.8.11",
     "rehype-katex": "^7.0.1",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       react-shiki:
         specifier: ^0.6.0
         version: 0.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-window:
+        specifier: ^1.8.11
+        version: 1.8.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
@@ -596,6 +599,10 @@ packages:
 
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.27.6':
+    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
     engines: {node: '>=6.9.0'}
 
   '@cloudflare/kv-asset-handler@0.4.0':
@@ -4086,6 +4093,9 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  memoize-one@5.2.1:
+    resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
@@ -4589,6 +4599,13 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-window@1.8.11:
+    resolution: {integrity: sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==}
+    engines: {node: '>8.0.0'}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
@@ -6339,6 +6356,8 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/runtime@7.27.6': {}
 
   '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:
@@ -10287,6 +10306,8 @@ snapshots:
 
   media-typer@1.1.0: {}
 
+  memoize-one@5.2.1: {}
+
   merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
@@ -10917,6 +10938,13 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.6
+
+  react-window@1.8.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.27.6
+      memoize-one: 5.2.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react@19.1.0: {}
 


### PR DESCRIPTION
## Summary
- fix API key store functions to avoid `getKey` errors
- adjust thread creation logic for invalid IDs
- improve error boundaries and error handling
- add app shell skeleton and fade-in transitions
- virtualize long message lists and memoize heavy drawers

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684debdfa1d4832ba284c101020bd766