### PR TITLE
Fix thread ID flow

### DIFF
--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -1,11 +1,13 @@
 import { fetchQuery } from 'convex/nextjs';
 import { api } from '@/convex/_generated/api';
 import Chat from '@/frontend/components/Chat';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
+import { isConvexId } from '@/lib/ids';
 
 export const dynamic = 'force-dynamic';
 
 export default async function ChatPage({ params }: { params: { id: string } }) {
+  if (!isConvexId(params.id)) redirect('/chat');
   const thread = await fetchQuery(api.threads.list).then(ts => ts.find(t => t._id === params.id));
   if (!thread) notFound();
   const messages = await fetchQuery(api.messages.get, { threadId: params.id });

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -18,6 +18,8 @@ import { useEffect, useState, useMemo } from 'react';
 import { useParams } from 'react-router';
 import { useMutation, useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
+import { isConvexId } from '@/lib/ids';
+import { toast } from 'sonner';
 import { Id } from '@/convex/_generated/dataModel';
 
 interface ChatProps {
@@ -104,6 +106,10 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
           }
         ],
       };
+      if (!isConvexId(threadId)) {
+        toast.error('Thread not yet created');
+        return;
+      }
       await sendMessage({
         threadId: threadId as Id<'threads'>,
         role: 'assistant',

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -25,6 +25,7 @@ import { useQuoteStore } from '@/frontend/stores/QuoteStore';
 import { AI_MODELS, AIModel, getModelConfig } from '@/lib/models';
 import { UIMessage } from 'ai';
 import { v4 as uuidv4 } from 'uuid';
+import { isConvexId } from '@/lib/ids';
 import { StopIcon } from './ui/icons';
 import { toast } from 'sonner';
 import { useMessageSummary } from '../hooks/useMessageSummary';
@@ -117,8 +118,8 @@ function PureChatInput({
     }
 
     let currentThreadId: Id<'threads'>;
-    const isConvexId = id && !id.includes('-');
-    if (!id || !isConvexId) {
+    const valid = isConvexId(id);
+    if (!id || !valid) {
       const newThreadId = await createThread({ title: 'New Chat' });
       navigate(`/chat/${newThreadId}`);
       currentThreadId = newThreadId;
@@ -158,6 +159,7 @@ function PureChatInput({
     createThread,
     sendMessage,
     navigate,
+    isConvexId,
   ]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/frontend/components/KeyPrompt.tsx
+++ b/frontend/components/KeyPrompt.tsx
@@ -1,8 +1,11 @@
 import { Button } from '@/frontend/components/ui/button';
 import { Key } from 'lucide-react';
 import { Link } from 'react-router';
+import { useAPIKeyStore } from '@/frontend/stores/APIKeyStore';
 
 export default function KeyPrompt() {
+  const { hasRequiredKeys, keysLoading } = useAPIKeyStore();
+  if (keysLoading || hasRequiredKeys()) return null;
   return (
     <div className="fixed bottom-6 left-1/2 z-50">
       <div className="flex items-center p-4 pr-5 border rounded-lg bg-background shadow-lg gap-4 max-w-md">

--- a/frontend/components/Message.tsx
+++ b/frontend/components/Message.tsx
@@ -19,6 +19,8 @@ import { useAPIKeyStore } from '@/frontend/stores/APIKeyStore';
 import { toast } from 'sonner';
 import { useNavigate } from 'react-router';
 import { v4 as uuidv4 } from 'uuid';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 
 function PureMessage({
@@ -47,10 +49,11 @@ function PureMessage({
   
   const saveKeys = () => { setKeys(localKeys); toast.success('API keys saved'); };
   const navigate = useNavigate();
+  const createThread = useMutation(api.threads.create);
   const canChat = useAPIKeyStore(state => state.hasRequiredKeys());
-  
+
   const handleNewChat = async () => {
-    const newId = uuidv4();
+    const newId = await createThread({ title: 'New Chat' });
     navigate(`/chat/${newId}`);
   };
 

--- a/frontend/components/MessageControls.tsx
+++ b/frontend/components/MessageControls.tsx
@@ -8,6 +8,8 @@ import { useAPIKeyStore } from '@/frontend/stores/APIKeyStore';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 import { useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
+import { isConvexId } from '@/lib/ids';
+import { toast } from 'sonner';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useNavigate } from 'react-router';
 
@@ -53,6 +55,11 @@ export default function MessageControls({
   const handleRegenerate = async () => {
     // stop the current request
     stop();
+
+    if (!isConvexId(threadId)) {
+      toast.error('Thread not yet created');
+      return;
+    }
 
     if (message.role === 'user') {
       await removeAfter({
@@ -120,6 +127,10 @@ export default function MessageControls({
           variant="ghost"
           size="icon"
           onClick={async () => {
+            if (!isConvexId(threadId)) {
+              toast.error('Thread not yet created');
+              return;
+            }
             const newId = await cloneThread({
               threadId: threadId as Id<'threads'>,
               title: 'New Branch',

--- a/frontend/components/MessageEditor.tsx
+++ b/frontend/components/MessageEditor.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner';
 import { useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
+import { isConvexId } from '@/lib/ids';
 
 export default function MessageEditor({
   threadId,
@@ -58,6 +59,10 @@ export default function MessageEditor({
   const editMessage = useMutation(api.messages.edit);
 
   const handleSave = async () => {
+    if (!isConvexId(threadId)) {
+      toast.error('Thread not yet created');
+      return;
+    }
     try {
       await removeAfter({
         threadId: threadId as Id<'threads'>,

--- a/frontend/components/NewChatButton.tsx
+++ b/frontend/components/NewChatButton.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import { useNavigate } from 'react-router';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
 import { Button } from './ui/button';
 import { Plus } from 'lucide-react';
 import { WithTooltip } from './WithTooltip';
@@ -12,15 +14,17 @@ interface NewChatButtonProps {
   size?: "default" | "sm" | "lg" | "icon";
 }
 
-export default function NewChatButton({ 
-  className, 
-  variant = "outline", 
-  size = "icon" 
+export default function NewChatButton({
+  className,
+  variant = "outline",
+  size = "icon"
 }: NewChatButtonProps) {
   const navigate = useNavigate();
+  const createThread = useMutation(api.threads.create);
 
-  const handleClick = () => {
-    navigate('/chat');
+  const handleClick = async () => {
+    const newId = await createThread({ title: 'New chat' });
+    navigate(`/chat/${newId}`);
   };
 
   return (

--- a/frontend/hooks/usePinnedThreads.ts
+++ b/frontend/hooks/usePinnedThreads.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { isConvexId } from '@/lib/ids';
 
 const PINNED_THREADS_KEY = 'pak-chat-pinned-threads';
 
@@ -11,7 +12,8 @@ export const usePinnedThreads = () => {
       const stored = localStorage.getItem(PINNED_THREADS_KEY);
       if (stored) {
         const parsed = JSON.parse(stored);
-        setPinnedThreadsState(new Set(parsed));
+        const valid = parsed.filter(isConvexId);
+        setPinnedThreadsState(new Set(valid));
       }
     } catch (error) {
       console.error('Failed to load pinned threads:', error);
@@ -19,9 +21,10 @@ export const usePinnedThreads = () => {
   }, []);
 
   const setPinnedThreads = (newPinned: Set<string>) => {
-    setPinnedThreadsState(newPinned);
+    const filtered = new Set([...newPinned].filter(isConvexId));
+    setPinnedThreadsState(filtered);
     try {
-      localStorage.setItem(PINNED_THREADS_KEY, JSON.stringify(Array.from(newPinned)));
+      localStorage.setItem(PINNED_THREADS_KEY, JSON.stringify(Array.from(filtered)));
     } catch (error) {
       console.error('Failed to save pinned threads:', error);
     }

--- a/frontend/routes/Home.tsx
+++ b/frontend/routes/Home.tsx
@@ -1,5 +1,3 @@
-import Chat from '@/frontend/components/Chat';
-import { v4 as uuidv4 } from 'uuid';
 import { UIMessage } from 'ai';
 import { useAPIKeyStore } from '@/frontend/stores/APIKeyStore';
 import KeyPrompt from '@/frontend/components/KeyPrompt';
@@ -20,8 +18,8 @@ export default function Home() {
   return (
     <>
       {!hasKeys && <KeyPrompt />}
-      <div className="fade-in">
-        <Chat threadId={uuidv4()} initialMessages={initialMessages} />
+      <div className="fade-in p-4 text-muted-foreground text-center">
+        Select a chat on the left or press +
       </div>
     </>
   );

--- a/lib/ids.ts
+++ b/lib/ids.ts
@@ -1,0 +1,2 @@
+export const isConvexId = (id?: string) =>
+  typeof id === 'string' && /^[a-z0-9]{24,32}$/i.test(id);


### PR DESCRIPTION
## Summary
- ensure new threads have Convex IDs by default
- clean pinned thread cache
- guard Chat components against invalid thread IDs
- avoid flashing API key prompt when keys are loaded

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684e09236d20832ba59fc13581a4e08f