### PR TITLE
Fix API key load handling

### DIFF
--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -71,7 +71,8 @@ function PureChatInput({
   messageCount,
 }: ChatInputProps) {
   // Все хуки должны быть вызваны до любых условных возвратов
-  const { hasRequiredKeys, keys, setKeys } = useAPIKeyStore();
+  const { hasRequiredKeys, keys, setKeys, keysLoading } = useAPIKeyStore();
+  if (keysLoading) return null; // hide input until keys are loaded
   const canChat = hasRequiredKeys();
   const { currentQuote, clearQuote } = useQuoteStore();
   const [localKeys, setLocalKeys] = useState(keys);


### PR DESCRIPTION
## Summary
- ensure `keysLoading` waits for settings fetch and user data
- only mark loading complete when keys are processed
- hide chat input until keys finish loading

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684e0eada8f8832b83f3dd2a989cb148