### PR TITLE
Fix Chat ref types

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -31,7 +31,7 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
   const { selectedModel } = useModelStore();
   const { isMobile } = useIsMobile();
   const panelRef = useRef<HTMLDivElement>(null);
-  const isHeaderVisible = useScrollHide({ threshold: 15, panelRef });
+  const isHeaderVisible = useScrollHide<HTMLDivElement>({ threshold: 15, panelRef });
   const navigate = useNavigate();
   // Track the current thread ID locally to ensure it exists before sending messages
   const [currentThreadId, setCurrentThreadId] = useState(threadId);

--- a/frontend/hooks/useScrollHide.ts
+++ b/frontend/hooks/useScrollHide.ts
@@ -1,18 +1,27 @@
 import { useState, useEffect, useCallback, RefObject } from 'react';
 
-interface UseScrollHideOptions {
+/**
+ * Options for {@link useScrollHide}.
+ *
+ * @template T Element type for the panel reference.
+ */
+interface UseScrollHideOptions<T extends HTMLElement = HTMLElement> {
+  /** Minimum scroll difference before the panel reacts. */
   threshold?: number;
+  /** Hides the panel when scrolling down if `true`. */
   hideOnScrollDown?: boolean;
+  /** Shows the panel when scrolling up if `true`. */
   showOnScrollUp?: boolean;
-  panelRef?: RefObject<HTMLElement>;
+  /** Optional ref to the panel element that moves with the scroll. */
+  panelRef?: RefObject<T | null>;
 }
 
-export function useScrollHide({
+export function useScrollHide<T extends HTMLElement = HTMLElement>({
   threshold = 10,
   hideOnScrollDown = true,
   showOnScrollUp = true,
   panelRef,
-}: UseScrollHideOptions = {}) {
+}: UseScrollHideOptions<T> = {}) {
   const [isVisible, setIsVisible] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
 


### PR DESCRIPTION
## Summary
- fix typing of `useScrollHide` hook
- make `Chat` pass the generic to `useScrollHide`

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684ec3ad11a0832b8aecc2a772b32bc3