### PR TITLE
Fix attachment handling with temporary IDs

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -89,7 +89,6 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
     messages,
     input,
     setInput,
-    append,
     setMessages,
     reload,
     stop,
@@ -165,7 +164,7 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
             threadId={currentThreadId}
             input={input}
             status={status}
-            append={append}
+            reload={reload}
             setInput={setInput}
             setMessages={setMessages}
             stop={stop}
@@ -193,7 +192,7 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
               threadId={currentThreadId}
               input={input}
               status={status}
-              append={append}
+              reload={reload}
               setInput={setInput}
               setMessages={setMessages}
               stop={stop}


### PR DESCRIPTION
## Summary
- pass `reload` to `ChatInput` instead of `append`
- store attachments using a temporary message ID
- update message ID and trigger `reload` after saving

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684f0e879b0c832b89df464311642de8