### PR TITLE
Add message versioning and patchContent mutation

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -20,7 +20,7 @@ export const maxDuration = 60;
 
 export async function POST(req: NextRequest) {
   try {
-    const { messages, model, apiKeys, net, threadId } = await req.json();
+    const { messages, model, apiKeys, threadId } = await req.json();
 
     const modelConfig = getModelConfig(model as AIModel);
     
@@ -125,10 +125,6 @@ export async function POST(req: NextRequest) {
       
       return result;
     });
-
-    const netType = (net ?? '4g') as string;
-    const chunking: 'line' | 'word' =
-      netType.includes('2g') || netType.includes('3g') ? 'line' : 'word';
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const options: any = {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -37,6 +37,8 @@ export default defineSchema({
     role: v.union(v.literal("user"), v.literal("assistant")),
     content: v.string(),
     createdAt: v.number(),
+    // Optional version for concurrent-safe updates
+    version: v.optional(v.number()),
   }).index("by_thread_and_time", ["threadId", "createdAt"]),
 
   // Attachments for messages


### PR DESCRIPTION
## Summary
- include optional `version` field in messages table
- init `version: 0` when sending a message
- add new `patchContent` mutation with access and version checks
- clean unused variables to pass lint

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684f5a324a08832b969847a281843237