### PR TITLE
Fix chat input positioning

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -20,7 +20,7 @@ export const maxDuration = 60;
 
 export async function POST(req: NextRequest) {
   try {
-    const { messages, model, apiKeys, net, threadId } = await req.json();
+    const { messages, model, apiKeys, threadId } = await req.json();
 
     const modelConfig = getModelConfig(model as AIModel);
     
@@ -126,9 +126,10 @@ export async function POST(req: NextRequest) {
       return result;
     });
 
-    const netType = (net ?? '4g') as string;
-    const chunking: 'line' | 'word' =
-      netType.includes('2g') || netType.includes('3g') ? 'line' : 'word';
+    // Determine how to chunk the output based on network speed (unused for now)
+    // const netType = (net ?? '4g') as string;
+    // const chunking: 'line' | 'word' =
+    //   netType.includes('2g') || netType.includes('3g') ? 'line' : 'word';
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const options: any = {


### PR DESCRIPTION
## Summary
- restructure chat layout to render `ChatInput` once with CSS positioning
- keep input centered when no messages and pinned to bottom when messages exist

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684f5a12a3f4832b97366a3f94501646