### PR TITLE
Fix race in initial chat creation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,6 +44,7 @@ export default function RootLayout({
         />
         <link rel="manifest" href="/manifest.webmanifest" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
       </head>
       <body suppressHydrationWarning className="antialiased font-sans font-mono">

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -70,6 +70,13 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
   const [hasInitialized, setHasInitialized] = useState(false);
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
   const [savedAssistantMessages, setSavedAssistantMessages] = useState<Set<string>>(new Set());
+
+  // Навигация после создания нового треда
+  useEffect(() => {
+    if (isConvexId(currentThreadId) && !threadId) {
+      navigate(`/chat/${currentThreadId}`, { replace: true });
+    }
+  }, [currentThreadId, threadId, navigate]);
   
   // Используем наш store, определенный выше
   const { versions: messageVersions, updateVersion } = useMessageVersionStore();


### PR DESCRIPTION
## Summary
- clean up ChatInput submission logic to create new threads sequentially
- navigate to newly created chat via effect in Chat component
- add meta tag for mobile web app capability

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684f66798160832b80ed778c8c895223