### PR TITLE
Add error boundary wrapping routes

### DIFF
--- a/frontend/app.tsx
+++ b/frontend/app.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router';
 import ChatLayout from './ChatLayout';
+import ErrorBoundary from './components/ErrorBoundary';
 import Home from './routes/Home';
 import Index from './routes/Index';
 import Settings from './routes/Settings';
@@ -9,29 +10,31 @@ import ProtectedRoute from './components/ProtectedRoute';
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Index />} />
-        <Route 
-          path="chat" 
-          element={
-            <ProtectedRoute>
-              <ChatLayout />
-            </ProtectedRoute>
-          }
-        >
-          <Route index element={<Home />} />
-          <Route path=":id" element={<ChatPage />} />
-        </Route>
-        <Route 
-            path="settings" 
+      <ErrorBoundary>
+        <Routes>
+          <Route path="/" element={<Index />} />
+          <Route
+            path="chat"
+            element={
+              <ProtectedRoute>
+                <ChatLayout />
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<Home />} />
+            <Route path=":id" element={<ChatPage />} />
+          </Route>
+          <Route
+            path="settings"
             element={
                 <ProtectedRoute>
                     <Settings />
                 </ProtectedRoute>
-            } 
-        />
-        <Route path="*" element={<p> Not found </p>} />
-      </Routes>
+            }
+          />
+          <Route path="*" element={<p> Not found </p>} />
+        </Routes>
+      </ErrorBoundary>
     </BrowserRouter>
   );
 }

--- a/frontend/components/ErrorBoundary.tsx
+++ b/frontend/components/ErrorBoundary.tsx
@@ -6,15 +6,24 @@ type Props = { children: React.ReactNode };
 type State = { error: Error | null };
 
 export default class ErrorBoundary extends React.Component<Props, State> {
+  // Track any rendering errors encountered in child components
   state: State = { error: null };
 
-  static getDerivedStateFromError(error: Error) {
+  // Update state so the next render shows the fallback UI
+  static getDerivedStateFromError(error: Error): State {
     return { error };
+  }
+
+  // Log error details for debugging purposes
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error('Uncaught error:', error, errorInfo);
   }
 
   render() {
     if (this.state.error) {
-      return <Error message={this.state.error.message} />;
+      return (
+        <Error message={`Something went wrong: ${this.state.error.message}`} />
+      );
     }
     return this.props.children;
   }


### PR DESCRIPTION
## Summary
- refine `ErrorBoundary.tsx` with logging and message customization
- wrap app routes in `ErrorBoundary`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684f7fbe505c832bb6b3126f9024251f