### PR TITLE
Fix PWA icon path

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -4,8 +4,12 @@
   "start_url": "/chat",
   "display": "standalone",
   "icons": [
-    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+    {
+      "src": "/favicon.ico",
+      "sizes": "any",
+      "type": "image/x-icon",
+      "purpose": "any"
+    }
   ],
   "theme_color": "#ffffff",
   "background_color": "#ffffff"


### PR DESCRIPTION
## Summary
- fix PWA icon paths in manifest

## Testing
- `pnpm lint`
- `curl -I http://localhost:3000/manifest.webmanifest`
- `CHROME_PATH=$(which chromium-browser) pnpm dlx lighthouse http://localhost:3000 --only-categories=pwa --quiet --output=json --output-path=lh.json --chrome-flags="--headless --no-sandbox"` *(fails: Unable to connect to Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684f91d3b924832bbf8fadd09dc02031