### PR TITLE
fix button ref forwarding

### DIFF
--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -35,25 +35,25 @@ const buttonVariants = cva(
   }
 );
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<'button'> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-  }) {
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<'button'> &
+    VariantProps<typeof buttonVariants> & {
+      asChild?: boolean;
+    }
+>(({ className, variant, size, asChild = false, ...props }, ref) => {
   const Comp = asChild ? Slot : 'button';
 
   return (
     <Comp
+      ref={ref}
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
   );
-}
+});
+
+Button.displayName = 'Button';
 
 export { Button, buttonVariants };


### PR DESCRIPTION
## Summary
- forward refs in the Button component so Radix `asChild` works

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684fa7defb7c832b905b93f845b7d14f