### PR TITLE
Fix assistant message save loop with new threads

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -176,7 +176,8 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
       (m) => m.role === 'assistant' && !isConvexId(m.id)
     );
 
-    if (unsavedAssistantMessage) {
+    // Skip saving until we have a valid thread ID to avoid server errors
+    if (unsavedAssistantMessage && isConvexId(currentThreadId)) {
       sendMessage({
         threadId: currentThreadId as Id<'threads'>,
         role: 'assistant',


### PR DESCRIPTION
## Summary
- avoid saving assistant messages when thread id is invalid

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684fac1a5b48832bb1bf472e461fb414