### PR TITLE
Fix page scrolling in chat

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -214,7 +214,7 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
   }, []);
 
   return (
-    <div className="w-full h-screen flex flex-col overflow-hidden">
+    <div className="w-full min-h-screen flex flex-col overflow-y-auto">
         {/* Верхние кнопки, навигация, логотип */}
         <div
           ref={panelRef}


### PR DESCRIPTION
## Summary
- allow vertical scrolling in Chat page by removing overflow restriction

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684fb47a22cc832ba00991bc214969f9