### PR TITLE
Fix virtual chat layout and navigation

### DIFF
--- a/frontend/components/Messages.tsx
+++ b/frontend/components/Messages.tsx
@@ -65,7 +65,9 @@ const LargeListBoundary = 20;
 
 export default function Messages(props: React.ComponentProps<typeof PureMessages>) {
   return props.messages.length > LargeListBoundary ? (
-    <VirtualMessages {...props} />
+    <div className="h-full flex-1">
+      <VirtualMessages {...props} />
+    </div>
   ) : (
     <PureMessagesMemo {...props} />
   );

--- a/frontend/components/NewChatButton.tsx
+++ b/frontend/components/NewChatButton.tsx
@@ -5,6 +5,8 @@ import { Plus } from 'lucide-react';
 import { WithTooltip } from './WithTooltip';
 import { cn } from '@/lib/utils';
 import { useNavigate } from 'react-router';
+import { useChatStore } from '@/frontend/stores/ChatStore';
+import { useQuoteStore } from '@/frontend/stores/QuoteStore';
 
 interface NewChatButtonProps {
   className?: string;
@@ -18,9 +20,13 @@ export default function NewChatButton({
   size = "icon"
 }: NewChatButtonProps) {
   const navigate = useNavigate();
+  const { setInput } = useChatStore();
+  const { clearQuote } = useQuoteStore();
 
   const handleClick = () => {
-    navigate('/chat');
+    setInput('');
+    clearQuote();
+    navigate('/chat', { state: { ts: Date.now() } });
   };
 
   return (

--- a/frontend/components/VirtualMessages.tsx
+++ b/frontend/components/VirtualMessages.tsx
@@ -1,4 +1,4 @@
-import { FixedSizeList as List } from 'react-window';
+import { VariableSizeList as List } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import PreviewMessage from './Message';
 import { UIMessage } from 'ai';
@@ -15,14 +15,21 @@ interface Props {
 }
 
 export default function VirtualMessages({ messages, ...rest }: Props) {
-  const itemHeight = 240;
+  const getItemSize = (index: number) => {
+    const msg = messages[index];
+    const textLength = msg.parts
+      .map((p) => (p.type === 'text' ? p.text.length : 0))
+      .reduce((a, b) => a + b, 0);
+    const lines = Math.max(1, Math.ceil(textLength / 80));
+    return 80 + lines * 24;
+  };
   return (
     <AutoSizer>
       {({ height, width }) => (
         <List
           height={height}
           itemCount={messages.length}
-          itemSize={itemHeight}
+          itemSize={getItemSize}
           width={width}
           overscanCount={4}
         >

--- a/frontend/routes/ChatPage.tsx
+++ b/frontend/routes/ChatPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useParams, useNavigate } from 'react-router';
+import { useParams, useNavigate, useLocation } from 'react-router';
 import { useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { isConvexId } from '@/lib/ids';
@@ -13,6 +13,7 @@ import { UIMessage } from 'ai';
 export default function ChatPage() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
 
   // Проверяем валидность ID
   useEffect(() => {
@@ -69,5 +70,11 @@ export default function ChatPage() {
     attachments: attachmentsMap[m._id] ?? [],
   }));
 
-  return <Chat key={id ?? 'new'} threadId={id ?? ''} initialMessages={messages} />;
+  return (
+    <Chat
+      key={location.key}
+      threadId={id ?? ''}
+      initialMessages={messages}
+    />
+  );
 }

--- a/frontend/routes/Home.tsx
+++ b/frontend/routes/Home.tsx
@@ -1,8 +1,10 @@
 import { UIMessage } from 'ai';
 import { useAPIKeyStore } from '@/frontend/stores/APIKeyStore';
 import Chat from '@/frontend/components/Chat';
+import { useLocation } from 'react-router';
 
 export default function Home() {
+  const location = useLocation();
   const eightDaysAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 8);
   const welcomeMessage: UIMessage = {
     id: 'welcome',
@@ -19,5 +21,11 @@ export default function Home() {
   const initialMessages = hasKeys ? [] : [welcomeMessage];
   
   // Используем Chat компонент с пустым threadId для новой беседы
-  return <Chat threadId="" initialMessages={initialMessages} />;
+  return (
+    <Chat
+      key={location.key}
+      threadId=""
+      initialMessages={initialMessages}
+    />
+  );
 }

--- a/frontend/stores/ChatStore.ts
+++ b/frontend/stores/ChatStore.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+
+interface ChatStoreState {
+  setInputFn: ((value: string) => void) | null;
+  registerInputSetter: (fn: (value: string) => void) => void;
+  setInput: (value: string) => void;
+}
+
+export const useChatStore = create<ChatStoreState>((set, get) => ({
+  setInputFn: null,
+  registerInputSetter: (fn) => set({ setInputFn: fn }),
+  setInput: (value) => {
+    const fn = get().setInputFn;
+    if (fn) fn(value);
+  },
+}));


### PR DESCRIPTION
## Summary
- ensure chat container stretches with `min-h-full flex-1`
- keep VirtualMessages in a full-height wrapper
- switch to `VariableSizeList` and compute item height
- persist assistant messages once on finish and flush patches when done
- reset input via global store when starting new chats
- force Chat remounts by using `location.key`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684fbd3214f4832ba4bfdada235f4f4e