### PR TITLE
Fix status handling in Chat component

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -192,7 +192,8 @@ export default function Chat({ threadId, initialMessages }: ChatProps) {
 
   // After generation ends, flush pending patches
   useEffect(() => {
-    if (status === 'done') {
+    // Status 'ready' means the assistant finished responding
+    if (status === 'ready') {
       const last = messages[messages.length - 1];
       if (last?.role === 'assistant' && isConvexId(last.id)) {
         const currentVersion =


### PR DESCRIPTION
## Summary
- ensure useChat status check uses 'ready' instead of 'done'
- clarify with a comment that 'ready' means streaming is finished

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684fbf3bcf84832bbbf8bc961a616498