### PR TITLE
Fix initial message reload

### DIFF
--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -181,6 +181,18 @@ function Chat({ threadId, initialMessages }: ChatProps) {
     setMessages(initialMessages);
   }, [threadId]);
 
+  // Если это новый чат и есть только одно сообщение пользователя,
+  // запускаем генерацию ответа после полной инициализации страницы
+  useEffect(() => {
+    if (
+      status === 'ready' &&
+      messages.length === 1 &&
+      messages[0].role === 'user'
+    ) {
+      reload();
+    }
+  }, [messages, status, reload]);
+
 
 
   // Persist final assistant content to DB once generation is complete

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -222,8 +222,6 @@ function PureChatInput({
         });
       }
 
-      // Явно запрашиваем ответ после отправки
-      setTimeout(() => reload(), 0);
     } catch (error) {
       toast.error('Failed to send message.');
       setInput(currentInput);
@@ -248,7 +246,6 @@ function PureChatInput({
     setMessages,
     complete,
     router,
-    reload,
     onThreadCreated,
   ]);
 


### PR DESCRIPTION
## Summary
- ensure first message triggers after navigation
- remove optimistic reload from ChatInput

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68500afa0128832b838f0382723a9c41