### PR TITLE
Fix chat remount issue

### DIFF
--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -216,7 +216,8 @@ function PureChatInput({
 
       // 5. Навигация и генерация заголовка только для новых тредов
       if (isNewThread) {
-        router.replace(`/chat/${threadIdToUse}`);
+        // Заменяем адрес без полного перемонтирования страницы
+        router.replace(`/chat/${threadIdToUse}`, { scroll: false });
         complete(finalMessage, {
           body: { threadId: threadIdToUse, messageId: dbMsgId, isTitle: true },
         });

--- a/frontend/routes/ChatPage.tsx
+++ b/frontend/routes/ChatPage.tsx
@@ -106,7 +106,7 @@ export default function ChatPage() {
   // ---------------------------------------------------------------------------
   return (
     <Chat
-      key={`${id}-${messages.length}`}
+      key={id as string}
       threadId={id as string}
       initialMessages={messages}
     />

--- a/frontend/routes/Home.tsx
+++ b/frontend/routes/Home.tsx
@@ -30,7 +30,7 @@ export default function Home() {
   // Используем Chat компонент с пустым threadId для новой беседы
   return (
     <Chat
-      key={searchParams.get('newChat') ?? 'new'}
+      key="new"
       threadId=""
       initialMessages={initialMessages}
     />


### PR DESCRIPTION
## Summary
- prevent unnecessary Chat remounts
- keep stable key on Home page
- avoid page reload when creating new thread

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68500d035628832b99989c2f40345682