### PR TITLE
Implement system welcome thread

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -24,6 +24,7 @@ export default defineSchema({
   threads: defineTable({
     userId: v.id("users"),
     title: v.string(),
+    system: v.optional(v.boolean()),
     createdAt: v.number(),
     pinned: v.optional(v.boolean()),
     clonedFrom: v.optional(v.id("threads")),

--- a/frontend/components/ChatHistoryDrawer.tsx
+++ b/frontend/components/ChatHistoryDrawer.tsx
@@ -122,8 +122,8 @@ function ChatHistoryDrawerComponent({ children, isOpen, setIsOpen }: ChatHistory
   );
 
   const handleNewChat = useCallback(() => {
-    router.replace('/chat');
-  handleOpenChange(false);
+    router.replace(`/chat?newChat=${Date.now()}`);
+    handleOpenChange(false);
   }, [router, handleOpenChange]);
 
   const formatDate = (date: Date) => {

--- a/frontend/components/Message.tsx
+++ b/frontend/components/Message.tsx
@@ -60,7 +60,7 @@ function PureMessage({
 
   const handleNewChat = () => {
     // Start a fresh chat without creating a thread upfront
-    router.push('/chat');
+    router.push(`/chat?newChat=${Date.now()}`);
   };
 
   const handleMobileMessageClick = () => {

--- a/frontend/hooks/useWelcomeThread.ts
+++ b/frontend/hooks/useWelcomeThread.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { useAPIKeyStore } from '@/frontend/stores/APIKeyStore';
+import { useRouter } from 'next/navigation';
+
+export default function useWelcomeThread() {
+  const router = useRouter();
+  const { hasRequiredKeys } = useAPIKeyStore();
+
+  const welcome = useQuery(api.threads.listSystem, {});
+  const createThread = useMutation(api.threads.create);
+  const sendMessage = useMutation(api.messages.send);
+
+  useEffect(() => {
+    if (hasRequiredKeys()) return;
+    (async () => {
+      let id = welcome?.[0]?._id;
+      if (!id) {
+        id = await createThread({ title: 'API Keys', system: true });
+        await sendMessage({
+          threadId: id,
+          role: 'assistant',
+          content: 'To use Pak.chat you need to enter your API keys.',
+        });
+      }
+      router.replace(`/chat/${id}`);
+    })();
+  }, [welcome, hasRequiredKeys, createThread, sendMessage, router]);
+}

--- a/frontend/routes/Home.tsx
+++ b/frontend/routes/Home.tsx
@@ -1,20 +1,13 @@
-import { UIMessage } from 'ai';
 import { useAPIKeyStore } from '@/frontend/stores/APIKeyStore';
 import Chat from '@/frontend/components/Chat';
 import { useSearchParams } from 'next/navigation';
 import MessageLoading from '@/frontend/components/ui/MessageLoading';
+import useWelcomeThread from '@/frontend/hooks/useWelcomeThread';
 
 export default function Home() {
+  useWelcomeThread();
   const searchParams = useSearchParams();
-  const eightDaysAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 8);
-  const welcomeMessage: UIMessage = {
-    id: 'welcome',
-    role: 'assistant' as const,
-    parts: [{ type: 'text', text: 'To use Pak.chat, you need to enter your API keys.' }],
-    content: 'To use Pak.chat, you need to enter your API keys.',
-    createdAt: eightDaysAgo,
-  };
-  const { hasRequiredKeys, keysLoading } = useAPIKeyStore();
+  const { keysLoading } = useAPIKeyStore();
 
   // Render a loading indicator until the API keys are ready
   if (keysLoading) {
@@ -24,15 +17,11 @@ export default function Home() {
       </div>
     );
   }
-  const hasKeys = hasRequiredKeys();
-  const initialMessages = hasKeys ? [] : [welcomeMessage];
-  
-  // Используем Chat компонент с пустым threadId для новой беседы
   return (
     <Chat
-      key="new"
+      key={searchParams.get('newChat') ?? 'new'}
       threadId=""
-      initialMessages={initialMessages}
+      initialMessages={[]}
     />
   );
 }


### PR DESCRIPTION
## Summary
- allow system threads in Convex schema
- add query for system threads and update thread creation
- create welcome thread via `useWelcomeThread`
- simplify `Home` page to use the new hook
- ensure fresh chats by adding a `newChat` query param

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685011e72978832b8affc74e7cff35ee