### PR TITLE
Improve auth state handling and query gating

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,9 +51,14 @@ export default function RootLayout({
         <Suspense fallback={<AppShellSkeleton />}>
           <ConvexClientProvider>
             <Providers>
-              <AuthListener />
-              <UserSync />
-              {children}
+              <AuthListener>
+                {() => (
+                  <>
+                    <UserSync />
+                    {children}
+                  </>
+                )}
+              </AuthListener>
             </Providers>
             <Toaster richColors position="top-right" />
           </ConvexClientProvider>

--- a/frontend/components/AuthListener.tsx
+++ b/frontend/components/AuthListener.tsx
@@ -2,7 +2,14 @@
 import { useAuthStore } from '@/frontend/stores/AuthStore';
 import { ReactNode, useEffect, useState } from 'react';
 
-export default function AuthListener({ children }: { children: ReactNode }) {
+interface AuthListenerProps {
+  /**
+   * Children as render function to signal when auth state is ready.
+   */
+  children: (authReady: boolean) => ReactNode;
+}
+
+export default function AuthListener({ children }: AuthListenerProps) {
   const init = useAuthStore((s) => s.init);
   const loading = useAuthStore((s) => s.loading);
   const [ready, setReady] = useState(false);
@@ -13,6 +20,7 @@ export default function AuthListener({ children }: { children: ReactNode }) {
     return unsub;
   }, [init]);
 
-  if (!ready || loading) return null;
-  return <>{children}</>;
+  // Provide a boolean indicator whether auth has finished initializing.
+  const authReady = ready && !loading;
+  return <>{children(authReady)}</>;
 }

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -18,7 +18,7 @@ import { useKeyboardInsets } from '../hooks/useKeyboardInsets';
 import { cn } from '@/lib/utils';
 import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
-import { useMutation, useQuery } from 'convex/react';
+import { useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { isConvexId } from '@/lib/ids';
 import { toast } from 'sonner';

--- a/frontend/components/ChatHistoryDrawer.tsx
+++ b/frontend/components/ChatHistoryDrawer.tsx
@@ -11,7 +11,8 @@ import { useRouter, useParams } from 'next/navigation';
 import { X, Pin, PinOff, Search, MessageSquare, Plus, Edit2, Check, GitBranch } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
-import { useQuery, useMutation, useConvexAuth } from 'convex/react';
+import { useMutation, useConvexAuth } from 'convex/react';
+import { useSafeConvexQuery } from '@/frontend/hooks/useSafeConvexQuery';
 import { api } from '@/convex/_generated/api';
 import type { Doc, Id } from '@/convex/_generated/dataModel';
 
@@ -36,9 +37,9 @@ function ChatHistoryDrawerComponent({ children, isOpen, setIsOpen }: ChatHistory
   const router = useRouter();
   const { isAuthenticated } = useConvexAuth();
   
-  const threads = useQuery(
+  const threads = useSafeConvexQuery<{}, Thread[]>(
     api.threads.list,
-    isAuthenticated ? undefined : "skip"
+    isAuthenticated ? {} : null
   );
   const removeThread = useMutation(api.threads.remove);
   const renameThread = useMutation(api.threads.rename);

--- a/frontend/components/ClientApp.tsx
+++ b/frontend/components/ClientApp.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import AuthListener from '@/frontend/components/AuthListener';
+import { AuthContext } from '@/frontend/contexts/AuthContext';
 
 // Dynamically load the SPA only on the client to avoid Firebase errors
 const App = dynamic(() => import('@/frontend/app'), { ssr: false });
@@ -9,7 +10,11 @@ const App = dynamic(() => import('@/frontend/app'), { ssr: false });
 export default function ClientApp() {
   return (
     <AuthListener>
-      <App />
+      {(authReady) => (
+        <AuthContext.Provider value={authReady}>
+          <App />
+        </AuthContext.Provider>
+      )}
     </AuthListener>
   );
 }

--- a/frontend/components/MessageControls.tsx
+++ b/frontend/components/MessageControls.tsx
@@ -6,10 +6,11 @@ import { UIMessage } from 'ai';
 import { UseChatHelpers } from '@ai-sdk/react';
 import { useAPIKeyStore } from '@/frontend/stores/APIKeyStore';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
-import { useMutation, useQuery } from 'convex/react';
+import { useMutation } from 'convex/react';
+import { useSafeConvexQuery } from '@/frontend/hooks/useSafeConvexQuery';
 import { api } from '@/convex/_generated/api';
 import { isConvexId } from '@/lib/ids';
-import type { Id } from '@/convex/_generated/dataModel';
+import type { Id, Doc } from '@/convex/_generated/dataModel';
 import { useRouter } from 'next/navigation';
 
 interface MessageControlsProps {
@@ -46,9 +47,9 @@ export default function MessageControls({
     api.messages.remove
   );
   const cloneThread = useMutation<typeof api.threads.clone>(api.threads.clone);
-  const thread = useQuery(
+  const thread = useSafeConvexQuery<{ threadId: Id<'threads'> }, Doc<'threads'> | null>(
     api.threads.get,
-    isConvexId(threadId) ? { threadId: threadId as Id<'threads'> } : 'skip'
+    isConvexId(threadId) ? { threadId: threadId as Id<'threads'> } : null
   );
   const router = useRouter();
 

--- a/frontend/contexts/AuthContext.ts
+++ b/frontend/contexts/AuthContext.ts
@@ -1,0 +1,8 @@
+'use client'
+import { createContext } from 'react';
+
+/**
+ * Indicates whether Firebase auth state has been initialized.
+ * Components can use this to delay data fetching until auth is ready.
+ */
+export const AuthContext = createContext(false);

--- a/frontend/hooks/useSafeConvexQuery.ts
+++ b/frontend/hooks/useSafeConvexQuery.ts
@@ -1,0 +1,18 @@
+'use client'
+import { useContext } from 'react';
+import { useQuery } from 'convex/react';
+import { AuthContext } from '@/frontend/contexts/AuthContext';
+
+/**
+ * Wrapper around Convex's useQuery that waits for auth to be ready
+ * and skips the request when args are null or auth is not ready.
+ */
+export function useSafeConvexQuery<Args extends Record<string, any>, Result>(
+  fn: any,
+  args: Args | null,
+) {
+  const authReady = useContext(AuthContext);
+  const skip = !authReady || args === null;
+  // Convex allows passing undefined to skip the query.
+  return skip ? undefined : (useQuery as any)(fn, args) as Result;
+}

--- a/frontend/routes/ChatPage.tsx
+++ b/frontend/routes/ChatPage.tsx
@@ -5,7 +5,8 @@ import { useParams, usePathname, useRouter } from 'next/navigation'
 import { useEffect, useMemo } from 'react'
 
 // Convex data hooks
-import { useQuery, useConvexAuth } from 'convex/react'
+import { useConvexAuth } from 'convex/react'
+import { useSafeConvexQuery } from '@/frontend/hooks/useSafeConvexQuery'
 import { api } from '@/convex/_generated/api'
 import { Id, Doc } from '@/convex/_generated/dataModel'
 
@@ -28,17 +29,17 @@ export default function ChatPage() {
   // ---------------------------------------------------------------------------
   const isValidId = useMemo(() => id && isConvexId(id), [id])
 
-  const thread = useQuery(
+  const thread = useSafeConvexQuery<{ threadId: Id<'threads'> }, Doc<'threads'> | null>(
     api.threads.get,
-    isValidId && isAuthenticated ? { threadId: id as Id<'threads'> } : 'skip'
+    isValidId && isAuthenticated ? { threadId: id as Id<'threads'> } : null
   )
-  const messagesResult = useQuery(
+  const messagesResult = useSafeConvexQuery<{ threadId: Id<'threads'> }, any>(
     api.messages.get,
-    isValidId && isAuthenticated ? { threadId: id as Id<'threads'> } : 'skip'
+    isValidId && isAuthenticated ? { threadId: id as Id<'threads'> } : null
   )
-  const attachments = useQuery(
+  const attachments = useSafeConvexQuery<{ threadId: Id<'threads'> }, any[]>(
     api.attachments.byThread,
-    isValidId ? { threadId: id as Id<'threads'> } : 'skip'
+    isValidId ? { threadId: id as Id<'threads'> } : null
   )
 
   // ---------------------------------------------------------------------------

--- a/frontend/stores/APIKeyStore.ts
+++ b/frontend/stores/APIKeyStore.ts
@@ -1,7 +1,9 @@
 import { create } from 'zustand';
 import { useEffect, useCallback } from 'react';
-import { useMutation, useQuery, useConvexAuth } from 'convex/react';
+import { useMutation, useConvexAuth } from 'convex/react';
+import { useSafeConvexQuery } from '@/frontend/hooks/useSafeConvexQuery';
 import { api } from '@/convex/_generated/api';
+import type { Doc } from '@/convex/_generated/dataModel';
 import { encryptData, decryptData } from '@/frontend/lib/crypto';
 import { useAuthStore } from './AuthStore';
 
@@ -39,15 +41,15 @@ export function useAPIKeyStore() {
   const { user } = useAuthStore();
 
   // Fetch the Convex user to ensure sync is complete
-  const convexUser = useQuery(
+  const convexUser = useSafeConvexQuery<{}, Doc<'users'> | null>(
     api.users.getCurrent,
-    isAuthenticated ? {} : 'skip'
+    isAuthenticated ? {} : null
   );
 
   // Only query settings once the user exists in Convex
-  const settings = useQuery(
+  const settings = useSafeConvexQuery<{}, Doc<'userSettings'> | null>(
     api.userSettings.get,
-    convexUser ? {} : 'skip'
+    convexUser ? {} : null
   );
   const saveApiKeys = useMutation(api.userSettings.saveApiKeys);
   

--- a/frontend/stores/SettingsStore.ts
+++ b/frontend/stores/SettingsStore.ts
@@ -1,7 +1,9 @@
 import { create, Mutate, StoreApi } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { useConvexAuth, useMutation, useQuery } from 'convex/react';
+import { useConvexAuth, useMutation } from 'convex/react';
+import { useSafeConvexQuery } from '@/frontend/hooks/useSafeConvexQuery';
 import { api } from '@/convex/_generated/api';
+import type { Doc } from '@/convex/_generated/dataModel';
 import { useEffect, useRef } from 'react';
 
 export const GENERAL_FONTS = ['Proxima Vara', 'System Font'] as const;
@@ -81,13 +83,13 @@ if (typeof window !== 'undefined') {
 
 export function useSettingsSync() {
   const { isAuthenticated } = useConvexAuth();
-  const convexUser = useQuery(
+  const convexUser = useSafeConvexQuery<{}, Doc<'users'> | null>(
     api.users.getCurrent,
-    isAuthenticated ? {} : 'skip'
+    isAuthenticated ? {} : null
   );
-  const settingsDoc = useQuery(
+  const settingsDoc = useSafeConvexQuery<{}, Doc<'userSettings'> | null>(
     api.userSettings.get,
-    convexUser ? {} : 'skip'
+    convexUser ? {} : null
   );
   const save = useMutation(api.userSettings.saveSettings);
 


### PR DESCRIPTION
## Summary
- add `AuthContext` and expose auth readiness
- refactor `AuthListener` to provide auth readiness via render prop
- wrap Convex queries with new `useSafeConvexQuery`
- gate data fetching with auth state in pages, components and stores
- adjust layout usage of `AuthListener`

## Testing
- `pnpm build`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68502e6c6e48832b86f273669938cf48