### PR TITLE
Fix streaming markdown & lint errors

### DIFF
--- a/app/chat/[...slug]/page.tsx
+++ b/app/chat/[...slug]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { use, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useConvexAuth } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Id, Doc } from '@/convex/_generated/dataModel';
@@ -37,7 +37,7 @@ export default function CatchAllChatPage({ params }: { params: { slug: string[] 
   const messages = useMemo(() => {
     if (!attachments || !messagesResult) return []; // Защита от undefined
 
-    const attachmentsMap: Record<string, any[]> = {}
+      const attachmentsMap: Record<string, Doc<'attachments'>[]> = {}
     attachments.forEach(a => {
       if (!a.messageId) return
       if (!attachmentsMap[a.messageId]) attachmentsMap[a.messageId] = []

--- a/frontend/components/Message.tsx
+++ b/frontend/components/Message.tsx
@@ -21,16 +21,6 @@ import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 
-const StreamingText = memo(({ content }: { content: string }) => {
-  const proseClasses = 'prose prose-base dark:prose-invert break-words max-w-none w-full';
-  return (
-    <div className={proseClasses}>
-      <div style={{ whiteSpace: 'pre-wrap' }}>{content}</div>
-    </div>
-  );
-});
-StreamingText.displayName = 'StreamingText';
-
 function PureMessage({
   threadId,
   message,
@@ -228,11 +218,7 @@ function PureMessage({
               onClick={handleMobileMessageClick}
             >
               <SelectableText messageId={message.id} disabled={isStreaming}>
-                {isStreaming ? (
-                  <StreamingText content={part.text} />
-                ) : (
-                  <MarkdownRenderer content={part.text} id={message.id} />
-                )}
+                <MarkdownRenderer content={part.text} id={message.id} />
               </SelectableText>
               {attachments && attachments.length > 0 && (
                 <div className="flex gap-2 flex-wrap mt-2">
@@ -300,7 +286,7 @@ function PureMessage({
 const PreviewMessage = memo(PureMessage, (prevProps, nextProps) => {
   if (prevProps.isStreaming !== nextProps.isStreaming) return false;
   if (prevProps.message.id !== nextProps.message.id) return false;
-  if (nextProps.isStreaming && prevProps.message.content !== nextProps.message.content) return false;
+  if (prevProps.message.content !== nextProps.message.content) return false;
   if (!nextProps.isStreaming && !equal(prevProps.message, nextProps.message)) return false;
   return true;
 });


### PR DESCRIPTION
## Summary
- remove temporary `StreamingText` and stream markdown directly
- simplify message memoization to track message content updates
- fix unused import and `any` type in chat page

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6850653ad1c4832b8160e7afadd3b377