### PR TITLE
Implement chat history preview and search

### DIFF
--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -31,6 +31,22 @@ export const get = query({
   },
 });
 
+/** Get latest messages for preview */
+export const preview = query({
+  args: { threadId: v.id("threads"), limit: v.optional(v.number()) },
+  async handler(ctx, { threadId, limit }) {
+    const uid = await currentUserId(ctx);
+    if (uid === null) return [];
+    const thread = await ctx.db.get(threadId);
+    if (!thread || thread.userId !== uid) return [];
+    return ctx.db
+      .query("messages")
+      .withIndex("by_thread_and_time", (q) => q.eq("threadId", threadId))
+      .order("desc")
+      .take(limit ?? 4);
+  },
+});
+
 /** Send a message */
 export const send = mutation({
   args: {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -29,7 +29,9 @@ export default defineSchema({
     pinned: v.optional(v.boolean()),
     clonedFrom: v.optional(v.id("threads")),
     forkedFromMessageId: v.optional(v.id("messages")),
-  }).index("by_user_and_time", ["userId", "createdAt"]),
+  })
+    .index("by_user_and_time", ["userId", "createdAt"])
+    .searchIndex("by_title", { searchField: "title" }),
 
   // Messages
   messages: defineTable({

--- a/convex/threads.ts
+++ b/convex/threads.ts
@@ -37,6 +37,28 @@ export const list = query({
   },
 });
 
+/** Search threads by title */
+export const search = query({
+  args: { searchQuery: v.string() },
+  async handler(ctx, args) {
+    const uid = await currentUserId(ctx);
+    if (uid === null) return [];
+    if (!args.searchQuery.trim()) {
+      return ctx.db
+        .query("threads")
+        .withIndex("by_user_and_time", (q) => q.eq("userId", uid))
+        .order("desc")
+        .collect();
+    }
+    return ctx.db
+      .query("threads")
+      .withSearchIndex("by_title", (q) =>
+        q.search("title", args.searchQuery).filter(q.eq("userId", uid))
+      )
+      .take(20);
+  },
+});
+
 /** List system threads for the authenticated user */
 export const listSystem = query({
   args: {},

--- a/frontend/components/ChatPreview.tsx
+++ b/frontend/components/ChatPreview.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+
+interface ChatPreviewProps {
+  threadId: Id<"threads"> | null;
+}
+
+export default function ChatPreview({ threadId }: ChatPreviewProps) {
+  const messages = useQuery(
+    api.messages.preview,
+    threadId ? { threadId, limit: 4 } : "skip"
+  );
+
+  if (!threadId) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        Hover a chat to preview
+      </div>
+    );
+  }
+
+  if (messages === undefined) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">Loading…</div>
+    );
+  }
+
+  if (messages.length === 0) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">No messages</div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-2 overflow-y-auto">
+      {messages
+        .slice()
+        .reverse()
+        .map((m) => (
+          <div key={m._id} className="text-sm text-muted-foreground">
+            {m.content}
+          </div>
+        ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add search index for thread titles
- support server-side search of threads
- fetch recent messages via new `preview` query
- display preview in history drawer with hover
- enable long press actions on mobile and polish UI

## Testing
- `pnpm lint` *(fails: ./app/chat/[...slug]/page.tsx no-unused-vars)*
- `pnpm build` *(fails during lint step)*

------
https://chatgpt.com/codex/tasks/task_e_685065317db8832b8b4e56e5a001a29e