### PR TITLE
Implement regeneration history, navigation toggles and PDF parsing

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -42,6 +42,16 @@ export default defineSchema({
     createdAt: v.number(),
     // Optional version for concurrent-safe updates
     version: v.optional(v.number()),
+    isEdited: v.optional(v.boolean()),
+    history: v.optional(
+      v.array(
+        v.object({
+          content: v.string(),
+          createdAt: v.number(),
+        })
+      )
+    ),
+    activeHistoryIndex: v.optional(v.number()),
   }).index("by_thread_and_time", ["threadId", "createdAt"]),
 
   // Attachments for messages

--- a/frontend/components/Message.tsx
+++ b/frontend/components/Message.tsx
@@ -20,6 +20,9 @@ import { useAPIKeyStore, type APIKeys } from '@/frontend/stores/APIKeyStore';
 import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
 
 function PureMessage({
   threadId,
@@ -49,6 +52,7 @@ function PureMessage({
   const { keys, setKeys } = useAPIKeyStore();
   const [localKeys, setLocalKeys] = useState<APIKeys>(keys);
   const { isMobile } = useIsMobile();
+  const switchVersion = useMutation(api.messages.switchVersion);
   
   useEffect(() => { setLocalKeys(keys); }, [keys]);
   
@@ -253,16 +257,47 @@ function PureMessage({
                 </div>
               )}
               {!isStreaming && (
-                <MessageControls
-                  threadId={threadId}
-                  content={part.text}
-                  message={message}
-                  setMessages={setMessages}
-                  reload={reload}
-                  stop={stop}
-                  isVisible={mobileControlsVisible}
-                  onToggleVisibility={() => setMobileControlsVisible(!mobileControlsVisible)}
-                />
+                <>
+                  <MessageControls
+                    threadId={threadId}
+                    content={part.text}
+                    message={message}
+                    setMessages={setMessages}
+                    reload={reload}
+                    stop={stop}
+                    isVisible={mobileControlsVisible}
+                    onToggleVisibility={() => setMobileControlsVisible(!mobileControlsVisible)}
+                  />
+                  {message.history && message.history.length > 1 && (
+                    <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground mt-1">
+                      <button
+                        onClick={() =>
+                          switchVersion({
+                            messageId: message.id as Id<'messages'>,
+                            direction: 'prev',
+                          })
+                        }
+                        className="px-1 hover:text-foreground"
+                      >
+                        ←
+                      </button>
+                      <span>
+                        {(message.activeHistoryIndex ?? message.history.length - 1) + 1}/{message.history.length}
+                      </span>
+                      <button
+                        onClick={() =>
+                          switchVersion({
+                            messageId: message.id as Id<'messages'>,
+                            direction: 'next',
+                          })
+                        }
+                        className="px-1 hover:text-foreground"
+                      >
+                        →
+                      </button>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           );

--- a/frontend/components/SettingsDrawer.tsx
+++ b/frontend/components/SettingsDrawer.tsx
@@ -9,15 +9,16 @@ import { Input } from './ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
 import { Badge } from './ui/badge';
 import { Label } from '@/components/ui/label';
-import { 
-  Settings, 
-  Palette, 
-  Key, 
-  Type, 
-  Monitor, 
-  Sun, 
+import {
+  Settings,
+  Palette,
+  Key,
+  Type,
+  Monitor,
+  Sun,
   Moon,
-  User
+  User,
+  SlidersHorizontal
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSettingsStore, GENERAL_FONTS, CODE_FONTS, THEMES, GeneralFont, CodeFont, Theme } from '@/frontend/stores/SettingsStore';
@@ -29,6 +30,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { FieldError, useForm, UseFormRegister } from 'react-hook-form';
 import { toast } from 'sonner';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
+import { Switch } from '@/frontend/components/ui/switch';
 
 interface SettingsDrawerProps {
   children: React.ReactNode;
@@ -334,6 +336,37 @@ const CustomizationTab = () => {
               <Moon className="h-4 w-4" />
               Dark
             </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Additional Features */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <SlidersHorizontal className="h-4 w-4" />
+            Features
+          </CardTitle>
+          <CardDescription className="text-sm">
+            Enable or disable experimental options
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="navbars" className="text-sm">Show navigation bars</Label>
+            <Switch
+              id="navbars"
+              checked={settings.showNavBars}
+              onCheckedChange={(v) => setSettings({ showNavBars: v })}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="save-regens" className="text-sm">Save regenerations</Label>
+            <Switch
+              id="save-regens"
+              checked={settings.saveRegenerations}
+              onCheckedChange={(v) => setSettings({ saveRegenerations: v })}
+            />
           </div>
         </CardContent>
       </Card>

--- a/frontend/components/ui/switch.tsx
+++ b/frontend/components/ui/switch.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import * as SwitchPrimitives from '@radix-ui/react-switch';
+import { cn } from '@/lib/utils';
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    ref={ref}
+    className={cn(
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      className,
+    )}
+    {...props}
+  >
+    <SwitchPrimitives.Thumb
+      className="pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/frontend/stores/SettingsStore.ts
+++ b/frontend/stores/SettingsStore.ts
@@ -17,6 +17,8 @@ type Settings = {
   codeFont: CodeFont;
   theme: Theme;
   hidePersonal: boolean;
+  showNavBars: boolean;
+  saveRegenerations: boolean;
 };
 
 type SettingsStore = {
@@ -51,6 +53,8 @@ const defaultSettings: Settings = {
   codeFont: 'Berkeley Mono',
   theme: 'light',
   hidePersonal: false,
+  showNavBars: true,
+  saveRegenerations: true,
 };
 
 export const useSettingsStore = create<SettingsStore>()(

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "next": "15.3.2",
     "next-pwa": "^5.6.0",
     "next-themes": "^0.4.6",
+    "pdf-parse": "^1.1.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      pdf-parse:
+        specifier: ^1.1.1
+        version: 1.1.1
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -5308,6 +5311,9 @@ packages:
       sass:
         optional: true
 
+  node-ensure@0.0.0:
+    resolution: {integrity: sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==}
+
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
@@ -5469,6 +5475,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pdf-parse@1.1.1:
+    resolution: {integrity: sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==}
+    engines: {node: '>=6.8.1'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -13119,6 +13129,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-ensure@0.0.0: {}
+
   node-releases@2.0.19: {}
 
   npm-run-path@4.0.1:
@@ -13288,6 +13300,13 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pdf-parse@1.1.1:
+    dependencies:
+      debug: 3.2.7
+      node-ensure: 0.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   picocolors@1.1.1: {}
 


### PR DESCRIPTION
## Summary
- avoid duplicate LLM requests by tracking submitted message
- add navigation bar visibility setting and regeneration history setting
- implement switch and save version mutations
- parse PDF attachments in LLM route
- add UI for switching message versions

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685141ce501c832baa7c8831a5bd1400