### PR TITLE
Fix regeneration implementation

### DIFF
--- a/frontend/components/ChatView.tsx
+++ b/frontend/components/ChatView.tsx
@@ -49,6 +49,7 @@ function ChatView({ threadId, initialMessages, showNavBars }: ChatViewProps) {
     setMessages,
     reload,
     stop,
+    append,
     status,
     error,
   } = useChat({
@@ -135,6 +136,7 @@ function ChatView({ threadId, initialMessages, showNavBars }: ChatViewProps) {
                 status={status}
                 setMessages={setMessages}
                 reload={reload}
+                append={append}
                 error={error}
                 stop={stop}
               />

--- a/frontend/components/Message.tsx
+++ b/frontend/components/Message.tsx
@@ -25,14 +25,18 @@ function PureMessage({
   threadId,
   message,
   setMessages,
+  messages,
   reload,
+  append,
   isStreaming,
   stop,
 }: {
   threadId: string;
   message: UIMessage;
   setMessages: UseChatHelpers['setMessages'];
+  messages: UIMessage[];
   reload: UseChatHelpers['reload'];
+  append: UseChatHelpers['append'];
   isStreaming: boolean;
   stop: UseChatHelpers['stop'];
 }) {
@@ -198,10 +202,12 @@ function PureMessage({
               {mode === 'view' && (
                 <MessageControls
                   threadId={threadId}
+                  messages={messages}
                   content={part.text}
                   message={message}
                   setMode={setMode}
                   setMessages={setMessages}
+                  append={append}
                   reload={reload}
                   stop={stop}
                   isVisible={mobileControlsVisible}
@@ -257,9 +263,11 @@ function PureMessage({
               {!isStreaming && (
                 <MessageControls
                   threadId={threadId}
+                  messages={messages}
                   content={part.text}
                   message={message}
                   setMessages={setMessages}
+                  append={append}
                   reload={reload}
                   stop={stop}
                   isVisible={mobileControlsVisible}

--- a/frontend/components/Messages.tsx
+++ b/frontend/components/Messages.tsx
@@ -13,6 +13,7 @@ function PureMessages({
   status,
   setMessages,
   reload,
+  append,
   error,
   stop,
 }: {
@@ -20,6 +21,7 @@ function PureMessages({
   messages: UIMessage[];
   setMessages: UseChatHelpers['setMessages'];
   reload: UseChatHelpers['reload'];
+  append: UseChatHelpers['append'];
   status: UseChatHelpers['status'];
   error: UseChatHelpers['error'];
   stop: UseChatHelpers['stop'];
@@ -33,11 +35,13 @@ function PureMessages({
       {messages.map((message) => (
         <PreviewMessage
           key={message.id}
+          messages={messages}
           threadId={threadId}
           message={message}
           isStreaming={
             status === 'streaming' && messages[messages.length - 1]?.id === message.id
           }
+          append={append}
           setMessages={setMessages}
           reload={reload}
           stop={stop}

--- a/frontend/components/VirtualMessages.tsx
+++ b/frontend/components/VirtualMessages.tsx
@@ -9,6 +9,7 @@ interface Props {
   threadId: string;
   setMessages: UseChatHelpers['setMessages'];
   reload: UseChatHelpers['reload'];
+  append: UseChatHelpers['append'];
   status: UseChatHelpers['status'];
   error: UseChatHelpers['error'];
   stop: UseChatHelpers['stop'];
@@ -37,10 +38,12 @@ export default function VirtualMessages({ messages, ...rest }: Props) {
             <div style={style}>
               <PreviewMessage
                 {...rest}
+                messages={messages}
                 message={messages[index]}
                 isStreaming={
                   rest.status === 'streaming' && index === messages.length - 1
                 }
+                append={rest.append}
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
- wire append into ChatView and Messages
- pass messages array to MessageControls
- rewrite regeneration logic to avoid DOM
- update version switching to edit messages in-place
- fix VirtualMessages to send new props

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6851afb977b0832ba86c71bb09f2256d