### PR TITLE
Fix extra closing div causing Next.js build failure

### DIFF
--- a/frontend/components/MessageControls.tsx
+++ b/frontend/components/MessageControls.tsx
@@ -168,7 +168,6 @@ export default function MessageControls({
           </Button>
         )}
       </div>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- fix JSX syntax in `MessageControls` by removing duplicate closing `div`

## Testing
- `pnpm run build`
- `pnpm exec vitest run` *(fails: Cannot find module '@storybook/nextjs-vite/preset')*

------
https://chatgpt.com/codex/tasks/task_e_6851cf6ab2a0832b93e9431c5026fb94