### PR TITLE
Refactor dropdown components and disable unavailable models

### DIFF
--- a/frontend/components/Providers.tsx
+++ b/frontend/components/Providers.tsx
@@ -4,10 +4,13 @@ import React from 'react';
 import { useSettings } from '@/frontend/hooks/useSettings';
 import { useSettingsSync } from '@/frontend/stores/SettingsStore';
 import { ThemeProvider } from '@/frontend/components/ui/ThemeProvider';
+import { useModelVisibilitySync } from '@/frontend/hooks/useModelVisibilitySync';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   useSettings();
   useSettingsSync();
+  // Sync model visibility (favorite models & enabled providers) with Convex
+  useModelVisibilitySync();
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
       {children}

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -97,7 +97,7 @@ export const MODEL_CONFIGS: Record<AIModel, ModelConfig> = {
     modelId: 'qwen/qwen3-32b',
     provider: 'groq',
     company: 'Groq',
-    reasoningEffort: 'default' as any,
+    // Use provider default reasoning effort
   },
 } as const satisfies Record<AIModel, ModelConfig>;
 


### PR DESCRIPTION
## Summary
- refactor dropdown components out of chat input
- disable model and provider controls when API keys are missing
- sync model visibility on app load

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ERR_PNPM_NO_SCRIPT)*

------
https://chatgpt.com/codex/tasks/task_e_685215c49b28832bacb9f36a518d1455