### PR TITLE
Fix scrollRef type mismatch

### DIFF
--- a/frontend/components/SettingsDrawer.tsx
+++ b/frontend/components/SettingsDrawer.tsx
@@ -70,7 +70,7 @@ interface ContentComponentProps {
   isMobile: boolean;
   tabs: { value: string; label: string; icon: string }[];
   getTabIcon: (iconName: string) => React.ReactNode;
-  scrollRef: React.RefObject<HTMLDivElement>;
+  scrollRef: React.RefObject<HTMLDivElement | null>;
 }
 
 const ContentComponent = memo(function ContentComponent({


### PR DESCRIPTION
## Summary
- fix type of scrollRef in ContentComponentProps

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68521dff1244832bb714c642cec495be