### PR TITLE
Fix messages undefined case

### DIFF
--- a/app/chat/[...slug]/page.tsx
+++ b/app/chat/[...slug]/page.tsx
@@ -56,9 +56,8 @@ export default function CatchAllChatPage({ params }: { params: Promise<{ slug: s
       attachmentsMap[a.messageId].push(a);
     });
 
-    const rawMessages: Doc<'messages'>[] = Array.isArray(messagesResult)
-      ? messagesResult
-      : messagesResult?.page || []
+    // Handle case where the query might still be loading.
+    const rawMessages: Doc<'messages'>[] = messagesResult ?? []
 
     return rawMessages.map(m => ({
       id: m._id,


### PR DESCRIPTION
## Summary
- remove incorrect usage of `messagesResult?.page`
- handle `messagesResult` directly

## Testing
- `pnpm lint` *(fails: Unexpected any, unused variables)*
- `pnpm build` *(fails: lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68528e14ea90832b8ab1b8365c2ecd03