### PR TITLE
Fix OpenAI models in settings

### DIFF
--- a/frontend/components/SettingsDrawer.tsx
+++ b/frontend/components/SettingsDrawer.tsx
@@ -629,7 +629,7 @@ const APIKeysTab = memo(() => {
             <ApiKeyField
               id="openai"
               label="OpenAI API Key"
-              models={['GPT-4o', 'GPT-4.1-mini']}
+              models={['GPT-4o', 'GPT-4.1-mini', 'GPT-4.1', 'GPT-4.1-nano', 'o4-mini']}
               linkUrl="https://platform.openai.com/settings/organization/api-keys"
               placeholder="sk-..."
               register={register}


### PR DESCRIPTION
## Summary
- list all OpenAI models in the settings drawer

## Testing
- `pnpm lint` *(fails: no-unused-vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6852ec01cfdc832bac1034a6475f30ac