### PR TITLE
Persist chat state and reduce flicker

### DIFF
--- a/app/chat/[...slug]/page.tsx
+++ b/app/chat/[...slug]/page.tsx
@@ -6,7 +6,6 @@ import { useQuery, useConvexAuth } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Id, Doc } from '@/convex/_generated/dataModel';
 import { isConvexId } from '@/lib/ids';
-import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 import Chat from '@/frontend/components/Chat';
 import ErrorBoundary from '@/frontend/components/ErrorBoundary';
 
@@ -16,7 +15,6 @@ function CatchAllChatPageInner({ params }: { params: Promise<{ slug: string[] }>
   
   const router = useRouter();
   const { isAuthenticated, isLoading: authLoading } = useConvexAuth();
-  const { isMobile, mounted } = useIsMobile();
   const [isInitialLoad, setIsInitialLoad] = useState(true);
 
   const isValidId = useMemo(() => isConvexId(chatId), [chatId]);

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -3,11 +3,9 @@ import Chat from '@/frontend/components/Chat';
 import { useConvexAuth } from 'convex/react';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
-import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 
 export default function NewChatPage() {
   const { isAuthenticated, isLoading } = useConvexAuth();
-  const { isMobile, mounted } = useIsMobile();
   const router = useRouter();
 
   useEffect(() => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import './globals.css';
 import 'katex/dist/katex.min.css';
 import { Toaster } from '@/frontend/components/ui/sonner';
 import Providers from '@/frontend/components/Providers';
-import AppShellSkeleton from '@/frontend/components/AppShellSkeleton';
 import { Suspense } from 'react';
 import AuthListener from '@/frontend/components/AuthListener';
 import ConvexClientProvider from '@/frontend/components/ConvexClientProvider';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useAuthStore } from '@/frontend/stores/AuthStore';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 import { Button } from '@/frontend/components/ui/button';
+import { getLastChatId } from '@/frontend/lib/lastChat';
 
 export default function IndexPage() {
   const { user, loading, login } = useAuthStore();
@@ -14,6 +15,11 @@ export default function IndexPage() {
   useEffect(() => {
     // Ждем пока mounted станет true, чтобы избежать неправильного перенаправления
     if (!loading && user && mounted) {
+      const lastId = getLastChatId();
+      if (lastId) {
+        router.push(`/chat/${lastId}`);
+        return;
+      }
       // ПК - сразу в чат, мобильные - в home с историей
       router.push(isMobile ? '/home' : '/chat');
     }

--- a/frontend/components/ChatHistoryList.tsx
+++ b/frontend/components/ChatHistoryList.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useIsMobile } from "@/frontend/hooks/useIsMobile";
+import { saveLastChatId, clearLastChatId } from "@/frontend/lib/lastChat";
 import { useQuery, useMutation, useConvexAuth } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Doc, Id } from "@/convex/_generated/dataModel";
@@ -146,6 +147,7 @@ function ChatHistoryList({
 
   const handleThreadClick = useCallback(
     (threadId: Id<"threads">) => {
+      saveLastChatId(threadId);
       if (onSelectThread) {
         onSelectThread(threadId);
       } else {
@@ -190,6 +192,7 @@ function ChatHistoryList({
       await removeThread({ threadId });
       if (id === threadId) {
         router.push("/chat");
+        clearLastChatId();
       }
       setDeletingThreadId(null);
       setLongPressThreadId(null);

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -38,6 +38,7 @@ import { useRecentFilesIntegration, addFileToRecent, addUploadedFileMetaToRecent
 import { getCompanyIcon } from '@/frontend/components/ui/provider-icons';
 import { useDebouncedCallback } from 'use-debounce';
 import { createImagePreview } from '@/frontend/lib/image';
+import { saveLastChatId } from '@/frontend/lib/lastChat';
 
 // Helper to convert File objects to Base64 data URLs
 const fileToDataUrl = (file: File): Promise<string> => {
@@ -623,6 +624,7 @@ function PureChatInput({
       // 2. Если тред новый, обновляем состояние без редиректа
       if (!isConvexId(threadId)) {
         onThreadCreated?.(ensuredThreadId);
+        saveLastChatId(ensuredThreadId);
         // Обновляем URL плавно без перезагрузки страницы (только на клиенте)
         if (typeof window !== 'undefined') {
           window.history.replaceState(null, '', `/chat/${ensuredThreadId}`);

--- a/frontend/components/ChatView.tsx
+++ b/frontend/components/ChatView.tsx
@@ -19,6 +19,7 @@ import type { UIMessage } from 'ai';
 import { useDebounceCallback } from 'usehooks-ts';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 import { loadDraft, saveDraft, clearDraft } from '@/frontend/lib/drafts';
+import { saveLastChatId } from '@/frontend/lib/lastChat';
 
 interface ChatViewProps {
   threadId: string;
@@ -250,6 +251,10 @@ function ChatView({ threadId, thread, initialMessages, showNavBars }: ChatViewPr
       if (draft.messages.length > 0) {
         setMessages((prev) => [...prev, ...draft.messages]);
       }
+    }
+    if (threadId) {
+      // Remember last active chat for automatic restoration on reload
+      saveLastChatId(threadId);
     }
   }, [threadId, setInput, clearQuote, clearAttachments, setMessages, initialMessages]);
 

--- a/frontend/hooks/useIsMobile.ts
+++ b/frontend/hooks/useIsMobile.ts
@@ -1,21 +1,19 @@
-import { useState, useEffect } from 'react';
+import { useState, useLayoutEffect } from 'react';
 
 export function useIsMobile(breakpoint: number = 768) {
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' ? window.innerWidth < breakpoint : false
+  );
   const [mounted, setMounted] = useState(false);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const checkMobile = () => {
       const isMobileDevice = window.innerWidth < breakpoint;
       setIsMobile(isMobileDevice);
       
-      // Устанавливаем mounted только после первой проверки
-      if (!mounted) {
-        setMounted(true);
-      }
+      if (!mounted) setMounted(true);
     };
     
-    // Немедленно проверяем при монтировании
     checkMobile();
     
     window.addEventListener('resize', checkMobile);

--- a/frontend/lib/lastChat.ts
+++ b/frontend/lib/lastChat.ts
@@ -1,0 +1,26 @@
+export const LAST_CHAT_KEY = 'last-chat-id';
+
+export function saveLastChatId(id: string) {
+  try {
+    localStorage.setItem(LAST_CHAT_KEY, id);
+  } catch {
+    // ignore
+  }
+}
+
+export function getLastChatId(): string | null {
+  try {
+    return localStorage.getItem(LAST_CHAT_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function clearLastChatId() {
+  try {
+    localStorage.removeItem(LAST_CHAT_KEY);
+  } catch {
+    // ignore
+  }
+}
+

--- a/frontend/stores/AuthStore.ts
+++ b/frontend/stores/AuthStore.ts
@@ -2,6 +2,7 @@ import { User, GoogleAuthProvider, signInWithPopup, signOut, onAuthStateChanged 
 import { create } from 'zustand';
 import { auth } from '@/firebase';
 import { useSettingsStore } from './SettingsStore';
+import { clearLastChatId } from '@/frontend/lib/lastChat';
 
 interface AuthState {
   user: User | null;
@@ -27,6 +28,7 @@ export const useAuthStore = create<AuthState>((set) => {
     async logout() {
       try {
         await signOut(auth);
+        clearLastChatId();
       } catch {
         /* ignore logout failure */
       }


### PR DESCRIPTION
## Summary
- keep track of last opened chat to return after reload
- persist last chat across history actions and logout
- trim unused variables
- improve mobile detection to avoid interface flashes

## Testing
- `pnpm lint`
- `pnpm vitest` *(fails: Cannot find module '@storybook/addon-vitest/vitest-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6852ec3e5fa0832ba8df30f9136c35c3