### PR TITLE
Fix missing useIsMobile imports

### DIFF
--- a/app/chat/[...slug]/page.tsx
+++ b/app/chat/[...slug]/page.tsx
@@ -8,6 +8,7 @@ import { Id, Doc } from '@/convex/_generated/dataModel';
 import { isConvexId } from '@/lib/ids';
 import Chat from '@/frontend/components/Chat';
 import ErrorBoundary from '@/frontend/components/ErrorBoundary';
+import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 
 function CatchAllChatPageInner({ params }: { params: Promise<{ slug: string[] }> }) {
   const resolvedParams = use(params);

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -3,6 +3,7 @@ import Chat from '@/frontend/components/Chat';
 import { useConvexAuth } from 'convex/react';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
+import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 
 export default function NewChatPage() {
   const { isAuthenticated, isLoading } = useConvexAuth();


### PR DESCRIPTION
## Summary
- add missing `useIsMobile` imports in chat pages

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Missing script)*
- `pnpm run build` *(fails: client created with undefined deployment address)*

------
https://chatgpt.com/codex/tasks/task_e_6852f3388560832b87f5272b9c73dfea