### PR TITLE
Fix mobile UI glitches and default settings

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -94,7 +94,7 @@ export default function HomePage() {
         <ChatHistoryList
           onSelectThread={handleSelectThread}
           onNewChat={handleNewChat}
-          showSearch={true}
+          showSearch={!isMobile}
           className="h-full"
         />
       </div>

--- a/frontend/components/ChatView.tsx
+++ b/frontend/components/ChatView.tsx
@@ -171,12 +171,13 @@ function ChatView({ threadId, thread, initialMessages, showNavBars }: ChatViewPr
         attachments: cm.attachments || [],
       }));
 
+    const getTime = (value: any) => {
+      if (!value) return 0;
+      return value instanceof Date ? value.getTime() : new Date(value).getTime();
+    };
+
     const allMessages = [...updatedMessages, ...missingConvexMessages]
-      .sort((a, b) => {
-        const aTime = a.createdAt ? a.createdAt.getTime() : Date.now();
-        const bTime = b.createdAt ? b.createdAt.getTime() : Date.now();
-        return aTime - bTime;
-      });
+      .sort((a, b) => getTime(a.createdAt) - getTime(b.createdAt));
 
     
     return allMessages;

--- a/frontend/components/SettingsDrawer.tsx
+++ b/frontend/components/SettingsDrawer.tsx
@@ -283,6 +283,7 @@ const CustomizationTab = memo(() => {
   const { settings, setSettings } = useSettingsStore();
   const { setTheme } = useTheme();
   const [featuresExpanded, setFeaturesExpanded] = useState(false);
+  const { isMobile } = useIsMobile();
 
   // Мемоизируем обработчики чтобы предотвратить ненужные перерендеры
   const handleFontChange = useCallback((type: 'generalFont' | 'codeFont', value: GeneralFont | CodeFont) => {
@@ -470,12 +471,18 @@ const CustomizationTab = memo(() => {
             </div>
 
             <div className="flex items-center justify-between">
-              <Label htmlFor="chat-preview" className="text-sm">Show chat preview</Label>
-              <Switch
-                id="chat-preview"
-                checked={settings.showChatPreview}
-                onCheckedChange={(v) => handleSwitchChange('showChatPreview', v)}
-              />
+              <Label htmlFor="chat-preview" className={cn('text-sm', isMobile && 'text-muted-foreground')}>
+                Show chat preview
+              </Label>
+              {isMobile ? (
+                <span className="text-muted-foreground text-xs select-none">Only For PC</span>
+              ) : (
+                <Switch
+                  id="chat-preview"
+                  checked={settings.showChatPreview}
+                  onCheckedChange={(v) => handleSwitchChange('showChatPreview', v)}
+                />
+              )}
             </div>
           </CardContent>
         )}

--- a/frontend/components/ui/CopyButton.tsx
+++ b/frontend/components/ui/CopyButton.tsx
@@ -12,12 +12,26 @@ export default function CopyButton({ code }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
 
   // Copy provided code snippet to the clipboard
-  const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(code).then(() => {
-      setCopied(true);
-      // Reset indicator after a short delay
-      setTimeout(() => setCopied(false), 2000);
-    });
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+    } catch {
+      // Fallback for older mobile browsers
+      const textarea = document.createElement('textarea');
+      textarea.value = code;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      try {
+        document.execCommand('copy');
+      } finally {
+        document.body.removeChild(textarea);
+      }
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   }, [code]);
 
   return (

--- a/frontend/hooks/useKeyboardInsets.ts
+++ b/frontend/hooks/useKeyboardInsets.ts
@@ -8,6 +8,7 @@ export function useKeyboardInsets(onChange: (height: number) => void) {
         : 0;
       onChange(height);
     };
+    handle();
     window.visualViewport?.addEventListener('resize', handle);
     return () => window.visualViewport?.removeEventListener('resize', handle);
   }, [onChange]);

--- a/frontend/stores/AuthStore.ts
+++ b/frontend/stores/AuthStore.ts
@@ -1,4 +1,4 @@
-import { User, GoogleAuthProvider, signInWithPopup, signOut, onAuthStateChanged } from 'firebase/auth';
+import { User, GoogleAuthProvider, signInWithRedirect, signOut, onAuthStateChanged } from 'firebase/auth';
 import { create } from 'zustand';
 import { auth } from '@/firebase';
 import { useSettingsStore } from './SettingsStore';
@@ -20,7 +20,7 @@ export const useAuthStore = create<AuthState>((set) => {
     async login() {
       set({ loading: true });
       try {
-        await signInWithPopup(auth, new GoogleAuthProvider());
+        await signInWithRedirect(auth, new GoogleAuthProvider());
       } finally {
         set({ loading: false });
       }

--- a/frontend/stores/SettingsStore.ts
+++ b/frontend/stores/SettingsStore.ts
@@ -52,7 +52,7 @@ const defaultSettings: Settings = {
   // Code font remains Berkeley Mono by default
   codeFont: 'Berkeley Mono',
   theme: 'light',
-  hidePersonal: false,
+  hidePersonal: true,
   showNavBars: true,
   showChatPreview: true,
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -33,6 +33,9 @@ const nextConfig = {
   turbopack: {
     resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.json', '.css'],
   },
+  images: {
+    domains: ['lh3.googleusercontent.com'],
+  },
 };
 
 export default withPWA(withAnalyzer(nextConfig));


### PR DESCRIPTION
## Summary
- enable Google avatar domain
- set user data blur on by default
- fix message sorting for non-Date timestamps
- tweak mobile layout and copy button
- switch to signInWithRedirect
- adjust keyboard insets handling
- disable chat preview toggle on mobile

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6852f83dde50832b9b54ebbc19169266