### PR TITLE
Fix next-pwa build

### DIFF
--- a/frontend/components/PullToRefresh.tsx
+++ b/frontend/components/PullToRefresh.tsx
@@ -156,5 +156,8 @@ export default function PullToRefresh({
           </div>
         </div>
       )}
-
+      {children}
+    </div>
+  );
+}
  

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,17 +15,13 @@ const withPWA = require('next-pwa')({
   publicExcludes: ['!sw.js'],
   buildExcludes: [/middleware-manifest\.json$/],
   cacheOnFrontEndNav: true,
-  aggressiveFrontEndNavCaching: true,
   reloadOnOnline: true,
-  swcMinify: true,
-  workboxOptions: {
-    disableDevLogs: true,
-    mode: 'production',
-    clientsClaim: true,
-    skipWaiting: true,
-    navigateFallback: '/offline',
-    navigateFallbackDenylist: [/^\/_/, /^\/api/],
-  }
+  disableDevLogs: true,
+  mode: 'production',
+  clientsClaim: true,
+  // skipWaiting defined above
+  navigateFallback: '/offline',
+  navigateFallbackDenylist: [/^\/_/, /^\/api/]
 });
 
 /** @type {import('next').NextConfig} */

--- a/package.json
+++ b/package.json
@@ -91,5 +91,6 @@
     "typescript": "^5.8.3",
     "vitest": "^3.2.3",
     "wrangler": "^4.19.1"
+    ,"babel-loader": "^8.4.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       '@types/react-window':
         specifier: ^1.8.8
         version: 1.8.8
+      babel-loader:
+        specifier: ^8.4.1
+        version: 8.4.1(@babel/core@7.27.4)(webpack@5.99.9)
       eslint:
         specifier: ^9.28.0
         version: 9.28.0(jiti@2.4.2)


### PR DESCRIPTION
## Summary
- add `babel-loader` dev dependency
- update next-pwa config
- close markup in `PullToRefresh`

## Testing
- `pnpm lint`
- `NEXT_PUBLIC_CONVEX_URL=http://localhost pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852fe92d194832b9239270af1fb9ce7