### PR TITLE
Translate PWA install prompt

### DIFF
--- a/frontend/components/PWAInstallPrompt.tsx
+++ b/frontend/components/PWAInstallPrompt.tsx
@@ -96,12 +96,12 @@ export default function PWAInstallPrompt() {
         
         <div className="flex-1 min-w-0">
           <h3 className="font-semibold text-sm text-foreground">
-            Установить Pak.Chat
+            Install Pak.Chat
           </h3>
           <p className="text-xs text-muted-foreground mt-1">
             {isIOS 
-              ? "Нажмите Share → Add to Home Screen для установки"
-              : "Установите приложение для лучшего опыта"
+              ? "Press Share → Add to Home Screen to install"
+              : "Install the app for a better experience"
             }
           </p>
           
@@ -112,7 +112,7 @@ export default function PWAInstallPrompt() {
                 onClick={handleInstall}
                 className="h-8 px-3 text-xs"
               >
-                Установить
+                Install
               </Button>
             )}
             
@@ -122,7 +122,7 @@ export default function PWAInstallPrompt() {
               onClick={handleDismiss}
               className="h-8 px-3 text-xs"
             >
-              Не сейчас
+              Not now
             </Button>
           </div>
         </div>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -28,7 +28,7 @@
     }
   ],
   "categories": ["productivity", "social"],
-  "description": "High-Performance LLM Application - чат с искусственным интеллектом",
+  "description": "High-Performance LLM Application - chat with artificial intelligence",
   "lang": "ru",
   "dir": "ltr",
   "prefer_related_applications": false,


### PR DESCRIPTION
## Summary
- switch install prompt text to English
- translate app description in manifest

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6853074e8ac8832bbea192e93d67525f