### PR TITLE
Fix mobile quoting & chat list layout

### DIFF
--- a/frontend/components/ChatHistoryList.tsx
+++ b/frontend/components/ChatHistoryList.tsx
@@ -290,9 +290,9 @@ function ChatHistoryList({
           }
         }}
         className={cn(
-          "group flex items-center justify-between rounded-lg px-2 py-1.5 cursor-pointer",
+          "group flex items-center justify-between rounded-lg px-2 py-2 min-h-12 cursor-pointer",
           id === thread._id
-            ? "bg-primary/10 border border-primary/20" 
+            ? "bg-primary/10 border border-primary/20"
             : (!isMobile && threadIndex === selectedThreadIndex)
             ? "bg-accent"
             : "hover:bg-accent",

--- a/frontend/components/QuoteButton.tsx
+++ b/frontend/components/QuoteButton.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { Quote as QuoteIcon } from 'lucide-react';
 import { Button } from './ui/button';
 import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 
 interface QuoteButtonProps {
   onQuote: () => void;
@@ -10,6 +11,12 @@ interface QuoteButtonProps {
 }
 
 function PureQuoteButton({ onQuote, position, className }: QuoteButtonProps) {
+  const { isMobile } = useIsMobile();
+
+  const top = isMobile
+    ? `calc(${position.y}px + env(safe-area-inset-top, 0px))`
+    : position.y;
+
   return (
     <div
       className={cn(
@@ -18,7 +25,7 @@ function PureQuoteButton({ onQuote, position, className }: QuoteButtonProps) {
       )}
       style={{
         left: position.x,
-        top: position.y,
+        top,
         zIndex: 9999,
       }}
     >

--- a/frontend/components/SelectableText.tsx
+++ b/frontend/components/SelectableText.tsx
@@ -64,25 +64,31 @@ function PureSelectableText({
             const buttonWidth = 80; // приблизительная ширина кнопки
 
             let posX = left + width / 2 - buttonWidth / 2;
-            
+
             // Горизонтальное ограничение с учетом мобильных устройств
             const margin = isMobile ? 16 : 8;
             posX = Math.max(margin, Math.min(posX, window.innerWidth - buttonWidth - margin));
 
             // Вертикальное позиционирование
             let posY = top - buttonHeight - 8;
-            
+
+            // Минимальный отступ от верхнего края на мобильных устройствах
+            const safeTop = isMobile ? 24 : 0;
+
             // Если не помещается сверху, показываем снизу
-            if (posY < margin) {
+            if (posY < margin + safeTop) {
               posY = bottom + 8;
             }
-            
+
             // Последняя проверка для нижнего края
             posY = Math.min(posY, window.innerHeight - buttonHeight - margin);
 
+            // Гарантируем отступ от верхней системной панели
+            posY = Math.max(posY, safeTop);
+
             // На мобильных устройствах добавляем дополнительный отступ снизу
             if (isMobile && posY > window.innerHeight - buttonHeight - 60) {
-              posY = top - buttonHeight - 8;
+              posY = Math.max(top - buttonHeight - 8, safeTop);
             }
 
             return { x: posX, y: posY };


### PR DESCRIPTION
## Summary
- adjust QuoteButton position for mobile safe areas
- ensure QuoteButton appears within viewport in SelectableText
- unify chat tile height for cleaner mobile layout

## Testing
- `pnpm lint`
- `pnpm vitest run` *(fails: Cannot find module '@storybook/addon-vitest/vitest-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68530e278150832b830df046efc285b9