### PR TITLE
Fix mobile copy and scroll

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -255,14 +255,9 @@
     padding-right: env(safe-area-inset-right);
   }
   
-  /* Предотвращение выделения текста на мобильных (кроме текстовых полей) */
+  /* Разрешаем выделение текста на мобильных устройствах */
   html {
     -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
   }
   
   /* Разрешаем выделение в текстовых полях */

--- a/frontend/components/ChatPreview.tsx
+++ b/frontend/components/ChatPreview.tsx
@@ -12,6 +12,7 @@ import SelectableText from "./SelectableText";
 import QuotedMessage from "./QuotedMessage";
 import { Button } from "./ui/button";
 import { Check, Copy, GitBranch } from "lucide-react";
+import { copyText } from '@/lib/copyText';
 import { useMutation, useQuery as useConvexQuery } from "convex/react";
 import { isConvexId } from "@/lib/ids";
 import { useRouter } from "next/navigation";
@@ -54,7 +55,7 @@ const PreviewMessageControls = memo(
     const router = useRouter();
 
     const handleCopy = () => {
-      navigator.clipboard.writeText(content);
+      copyText(content);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     };

--- a/frontend/components/MemoizedMarkdown.tsx
+++ b/frontend/components/MemoizedMarkdown.tsx
@@ -8,6 +8,7 @@ import type { ComponentProps } from 'react';
 import type { ExtraProps } from 'react-markdown';
 import { Check, Copy, Download } from 'lucide-react';
 import { useCallback } from 'react';
+import { copyText } from '@/lib/copyText';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 
@@ -67,7 +68,7 @@ function Codebar({ lang, codeString }: { lang: string; codeString: string }) {
 
   const copyToClipboard = async () => {
     try {
-      await navigator.clipboard.writeText(codeString);
+      await copyText(codeString);
       setCopied(true);
       setTimeout(() => {
         setCopied(false);

--- a/frontend/components/MessageControls.tsx
+++ b/frontend/components/MessageControls.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 import { Check, Copy, RefreshCcw, SquarePen, GitBranch } from 'lucide-react';
 import { UIMessage } from 'ai';
 import { UseChatHelpers } from '@ai-sdk/react';
+import { copyText } from '@/lib/copyText';
 import { useAPIKeyStore } from '@/frontend/stores/APIKeyStore';
 import { useModelStore } from '@/frontend/stores/ModelStore';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
@@ -73,7 +74,7 @@ export default function MessageControls({
 
   // Copy message contents to clipboard.
   const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(content);
+    copyText(content);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }, [content]);

--- a/frontend/components/MobileChatMenu.tsx
+++ b/frontend/components/MobileChatMenu.tsx
@@ -5,6 +5,7 @@ import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { MoreHorizontal, Share2, Edit2, Trash2, Pin, PinOff, Check, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { copyText } from '@/lib/copyText';
 import { useRouter } from 'next/navigation';
 import { useMutation, useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
@@ -95,7 +96,7 @@ export default function MobileChatMenu({ threadId, className }: MobileChatMenuPr
 
   const copyShareLink = () => {
     if (shareLink) {
-      navigator.clipboard.writeText(shareLink);
+      copyText(shareLink);
     }
   };
 

--- a/frontend/components/ScrollToBottomButton.tsx
+++ b/frontend/components/ScrollToBottomButton.tsx
@@ -56,6 +56,7 @@ export default function ScrollToBottomButton({
         className
       )}
       onClick={scrollToBottom}
+      style={{ touchAction: 'manipulation' }}
       {...props}
     >
       <ChevronDown className="h-4 w-4" />

--- a/frontend/components/SettingsDrawer.tsx
+++ b/frontend/components/SettingsDrawer.tsx
@@ -48,6 +48,7 @@ import { toast } from 'sonner';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 import { Switch } from '@/frontend/components/ui/switch';
 import { CustomSwitch } from '@/frontend/components/ui/custom-switch';
+import { copyText } from '@/lib/copyText';
 
 interface SettingsDrawerProps {
   children: React.ReactNode;
@@ -707,7 +708,7 @@ const ApiKeyField = ({
   const handleCopy = useCallback(async () => {
     if (inputValue.trim()) {
       try {
-        await navigator.clipboard.writeText(inputValue.trim());
+        await copyText(inputValue.trim());
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
       } catch (err) {

--- a/frontend/components/ui/CopyButton.tsx
+++ b/frontend/components/ui/CopyButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from 'react';
 import { Check, Copy } from 'lucide-react';
+import { copyText } from '@/lib/copyText';
 
 interface CopyButtonProps {
   /** Text that will be copied to the clipboard */
@@ -13,23 +14,7 @@ export default function CopyButton({ code }: CopyButtonProps) {
 
   // Copy provided code snippet to the clipboard
   const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(code);
-    } catch {
-      // Fallback for older mobile browsers
-      const textarea = document.createElement('textarea');
-      textarea.value = code;
-      textarea.style.position = 'fixed';
-      textarea.style.opacity = '0';
-      document.body.appendChild(textarea);
-      textarea.focus();
-      textarea.select();
-      try {
-        document.execCommand('copy');
-      } finally {
-        document.body.removeChild(textarea);
-      }
-    }
+    await copyText(code);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }, [code]);

--- a/lib/copyText.ts
+++ b/lib/copyText.ts
@@ -1,0 +1,19 @@
+// Utility to copy text to clipboard with mobile fallback
+export async function copyText(text: string) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    try {
+      document.execCommand('copy');
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow text selection on mobile
- add cross-browser copy utility
- use copy helper across the app
- improve scroll-to-bottom button on mobile

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to collect page data)*

------
https://chatgpt.com/codex/tasks/task_e_6853d0d44704832babb0d6c1e41393c2