### PR TITLE
Fix missing image previews after sending

### DIFF
--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -751,12 +751,17 @@ function PureChatInput({
       }
 
       // 7. Теперь, когда файлы загружены и привязаны к сообщению (или их не было), отправляем запрос к LLM
+      const attachmentsForUI = savedAttachments.map((a) => ({
+        id: a.id,
+        url: a.url ?? '',
+        name: a.name,
+        type: a.type,
+        ext: a.name.split('.').pop() ?? '',
+        size: a.size,
+      }));
+
       append(
-        {
-          id: dbMsgId,
-          role: 'user',
-          content: finalMessage,
-        } as any,
+        createUserMessage(dbMsgId, finalMessage, attachmentsForUI),
         {
           body: {
             model: selectedModel,


### PR DESCRIPTION
## Summary
- show uploaded attachments in the new message so image previews remain visible after sending

## Testing
- `pnpm lint`
- `pnpm exec vitest run` *(fails: cannot find module '@storybook/nextjs-vite/preset')*

------
https://chatgpt.com/codex/tasks/task_e_6853d18ef948832b8162936473c52467