### PR TITLE
Fix broken image previews from recent files

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -54,6 +54,12 @@ const nextConfig = {
   },
   images: {
     domains: ['lh3.googleusercontent.com'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**.convex.cloud',
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
## Summary
- allow Convex storage domain for `next/image`

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Client created with undefined deployment address)*

------
https://chatgpt.com/codex/tasks/task_e_6853d887ec14832b880cb738654bf274