### PR TITLE
Fix photo handling with HEIC conversion

### DIFF
--- a/frontend/components/AddActionsDropdown.tsx
+++ b/frontend/components/AddActionsDropdown.tsx
@@ -13,6 +13,7 @@ import { useAttachmentsStore } from '../stores/AttachmentsStore';
 import DrawingCanvas from './DrawingCanvas';
 import RecentFilesDropdown from './RecentFilesDropdown';
 import { toast } from 'sonner';
+import { convertToSupportedImage } from '../lib/fileHelpers';
 
 interface AddActionsDropdownProps {
   className?: string;
@@ -28,9 +29,12 @@ export default function AddActionsDropdown({ className, messageCount = 0 }: AddA
     fileInputRef.current?.click();
   };
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? []);
-    files.forEach(add);
+    for (const file of files) {
+      const processed = await convertToSupportedImage(file);
+      add(processed);
+    }
     e.target.value = '';
   };
 

--- a/frontend/components/AttachmentsBar.tsx
+++ b/frontend/components/AttachmentsBar.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { useAttachmentsStore } from '../stores/AttachmentsStore';
 import AddActionsDropdown from './AddActionsDropdown';
 import FilePreview from './FilePreview';
+import { convertToSupportedImage } from '../lib/fileHelpers';
 
 interface AttachmentsBarProps {
   mode?: 'compact' | 'full';
@@ -38,9 +39,12 @@ export default function AttachmentsBar({ mode = 'full', messageCount = 0 }: Atta
         hidden
         multiple
         accept="image/*,application/pdf,text/*"
-        onChange={(e) => {
+        onChange={async (e) => {
           const files = Array.from(e.target.files ?? []);
-          files.forEach(add);
+          for (const file of files) {
+            const processed = await convertToSupportedImage(file);
+            add(processed);
+          }
           e.target.value = '';
         }}
       />

--- a/frontend/components/MessageEditor.tsx
+++ b/frontend/components/MessageEditor.tsx
@@ -18,6 +18,7 @@ import QuoteDisplay from './QuoteDisplay';
 import { cn } from '@/lib/utils';
 import { PlusIcon, X } from 'lucide-react';
 import { createImagePreview } from '@/frontend/lib/image';
+import { convertToSupportedImage } from '../lib/fileHelpers';
 import FilePreview from './FilePreview';
 import type { Attachment, LocalAttachment, RemoteAttachment } from '@/frontend/stores/AttachmentsStore';
 
@@ -67,9 +68,12 @@ function EditAttachmentsBar({
         hidden
         multiple
         accept="image/*,application/pdf,text/*"
-        onChange={(e) => {
+        onChange={async (e) => {
           const files = Array.from(e.target.files ?? []);
-          files.forEach(onAdd);
+          for (const file of files) {
+            const processed = await convertToSupportedImage(file);
+            onAdd(processed);
+          }
           e.target.value = '';
         }}
       />

--- a/frontend/lib/fileHelpers.ts
+++ b/frontend/lib/fileHelpers.ts
@@ -1,0 +1,57 @@
+import heic2any from 'heic2any';
+
+export async function convertToSupportedImage(file: File): Promise<File> {
+  if (!file.type.startsWith('image/')) {
+    return file;
+  }
+
+  const type = file.type.toLowerCase();
+  if (['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'].includes(type)) {
+    return file;
+  }
+
+  if (type === 'image/heic' || type === 'image/heif') {
+    try {
+      const converted = (await heic2any({ blob: file, toType: 'image/jpeg', quality: 0.9 })) as Blob;
+      return new File([converted], file.name.replace(/\.[^/.]+$/, '.jpg'), { type: 'image/jpeg' });
+    } catch (err) {
+      console.error('HEIC conversion failed:', err);
+      return file;
+    }
+  }
+
+  // Fallback conversion using canvas for other image types (e.g., TIFF)
+  try {
+    const dataUrl: string = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+
+    const img: HTMLImageElement = await new Promise((resolve, reject) => {
+      const i = new Image();
+      i.onload = () => resolve(i);
+      i.onerror = reject;
+      i.src = dataUrl;
+    });
+
+    const canvas = document.createElement('canvas');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Canvas not supported');
+    ctx.drawImage(img, 0, 0);
+
+    const blob: Blob | null = await new Promise((resolve) => {
+      canvas.toBlob((b) => resolve(b), 'image/jpeg', 0.9);
+    });
+    if (blob) {
+      return new File([blob], file.name.replace(/\.[^/.]+$/, '.jpg'), { type: 'image/jpeg' });
+    }
+  } catch (err) {
+    console.error('Image conversion failed:', err);
+  }
+
+  return file;
+}

--- a/frontend/types/heic2any.d.ts
+++ b/frontend/types/heic2any.d.ts
@@ -1,0 +1,7 @@
+declare module 'heic2any' {
+  export default function heic2any(options: {
+    blob: Blob;
+    toType?: string;
+    quality?: number;
+  }): Promise<Blob>;
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "fast-deep-equal": "^3.1.3",
     "firebase": "^11.9.1",
     "framer-motion": "^12.18.1",
+    "heic2any": "^0.0.4",
     "katex": "^0.16.22",
     "lucide-react": "^0.510.0",
     "marked": "^15.0.12",
@@ -82,6 +83,7 @@
     "@types/react-dom": "^19.1.6",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@types/react-window": "^1.8.8",
+    "babel-loader": "^8.4.1",
     "eslint": "^9.28.0",
     "eslint-config-next": "15.3.2",
     "eslint-plugin-jsx-a11y": "^6.8.0",
@@ -91,6 +93,5 @@
     "typescript": "^5.8.3",
     "vitest": "^3.2.3",
     "wrangler": "^4.19.1"
-    ,"babel-loader": "^8.4.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       framer-motion:
         specifier: ^12.18.1
         version: 12.18.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      heic2any:
+        specifier: ^0.0.4
+        version: 0.0.4
       katex:
         specifier: ^0.16.22
         version: 0.16.22
@@ -4751,6 +4754,9 @@ packages:
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  heic2any@0.0.4:
+    resolution: {integrity: sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==}
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -12796,6 +12802,8 @@ snapshots:
       hast-util-parse-selector: 4.0.0
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
+
+  heic2any@0.0.4: {}
 
   highlight.js@10.7.3: {}
 


### PR DESCRIPTION
## Summary
- add heic2any package for HEIC support
- convert images to JPEG when uploading
- handle the conversion in AttachmentsBar, AddActionsDropdown and MessageEditor

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to collect page data for /api/files/[storageId])*

------
https://chatgpt.com/codex/tasks/task_e_6853dbc169b4832b9666b2aeee69a794