### PR TITLE
fix: исправить прокрутку в окне истории чатов - справлена проблема с …

### DIFF
--- a/frontend/components/ChatHistoryDrawer.tsx
+++ b/frontend/components/ChatHistoryDrawer.tsx
@@ -675,7 +675,7 @@ function ChatHistoryDrawerComponent({
 
   // ------------------ Main scrollable content component --------------
   const ContentComponent: React.FC = () => (
-    <div className="flex h-full flex-col">
+    <div className="h-full flex flex-col">
       <div className="flex-1 overflow-y-auto scrollbar-none enhanced-scroll px-3 sm:px-4">
         <div className="space-y-4 sm:space-y-6 pt-2 pb-8">
           {threadGroups.length === 0 ? (
@@ -707,7 +707,7 @@ function ChatHistoryDrawerComponent({
         </div>
       </div>
       {!isMobile && (
-        <div className="px-4 py-3 border-t border-border bg-muted/30 pointer-events-none">
+        <div className="px-4 py-3 border-t border-border bg-muted/30 pointer-events-none flex-shrink-0">
           <div className="flex items-center gap-4 text-xs text-muted-foreground">
             <div className="flex items-center gap-1">
               <kbd className="px-1.5 py-0.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg dark:bg-gray-600 dark:text-gray-100 dark:border-gray-500">
@@ -840,15 +840,15 @@ function ChatHistoryDrawerComponent({
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className={cn(
-        "w-[85vw] sm:max-w-none max-w-none h-[80vh] p-0 [&>button]:top-2 [&>button]:right-2 overflow-hidden focus:outline-none",
+        "w-[85vw] sm:max-w-none max-w-none h-[80vh] p-0 [&>button]:top-2 [&>button]:right-2 overflow-hidden focus:outline-none grid-rows-none",
         !settings.showChatPreview && "w-[600px] max-w-[600px]"
       )}>
         <div className={cn(
-          "grid h-full",
+          "grid h-full grid-rows-1",
           settings.showChatPreview ? "grid-cols-[1fr_600px]" : "grid-cols-1"
         )}>
-          <div className="flex flex-col overflow-hidden">
-            <DialogHeader className="px-4 pt-4 pb-2 flex flex-col gap-2 shrink-0">
+          <div className="relative h-full">
+            <DialogHeader className="px-4 pt-4 pb-2 flex flex-col gap-2">
               <DialogTitle className="flex items-center gap-2">
                 <MessageSquare className="h-5 w-5" /> Chat History
                 <Button
@@ -873,7 +873,7 @@ function ChatHistoryDrawerComponent({
                 <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground size-3.5" />
               </div>
             </DialogHeader>
-            <div className="flex-1 min-h-0 overflow-hidden">
+            <div className="absolute top-[120px] left-0 right-0 bottom-0">
               <ContentComponent />
             </div>
           </div>


### PR DESCRIPTION
…прокруткой колёсиком мыши и трекпадом в десктоп версии - одсказки навигации теперь корректно закреплены внизу окна - птимизированы hover события для предотвращения падения FPS - Структура layout изменена на абсолютное позиционирование как в ChatPreview - previewThreadId теперь null когда превью отключено в настройках