### PR TITLE
Fix navigation and page reload behavior

### DIFF
--- a/app/chat/[...slug]/page.tsx
+++ b/app/chat/[...slug]/page.tsx
@@ -9,6 +9,7 @@ import { isConvexId } from '@/lib/ids';
 import Chat from '@/frontend/components/Chat';
 import ErrorBoundary from '@/frontend/components/ErrorBoundary';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
+import { saveLastChatId, saveLastPath } from '@/frontend/lib/lastChat';
 
 function CatchAllChatPageInner({ params }: { params: Promise<{ slug: string[] }> }) {
   const resolvedParams = use(params);
@@ -90,6 +91,13 @@ function CatchAllChatPageInner({ params }: { params: Promise<{ slug: string[] }>
     }
     if (thread === null) {
       router.replace('/chat');
+      return;
+    }
+    
+    // Если чат успешно загружен, сохраняем его как последний
+    if (thread && isValidId) {
+      saveLastChatId(chatId);
+      saveLastPath(`/chat/${chatId}`);
     }
   }, [authLoading, isAuthenticated, isValidId, router, chatId, thread]);
 
@@ -107,6 +115,10 @@ function CatchAllChatPageInner({ params }: { params: Promise<{ slug: string[] }>
   useEffect(() => {
     if (!isLoading) {
       setIsInitialLoad(false);
+      // Скрываем глобальный лоадер когда страница готова
+      if (typeof window !== 'undefined' && (window as any).__hideGlobalLoader) {
+        (window as any).__hideGlobalLoader();
+      }
     }
   }, [isLoading]);
 

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -4,6 +4,7 @@ import { useConvexAuth } from 'convex/react';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
+import { saveLastPath } from '@/frontend/lib/lastChat';
 
 export default function NewChatPage() {
   const { isAuthenticated, isLoading } = useConvexAuth();
@@ -16,6 +17,17 @@ export default function NewChatPage() {
       router.replace('/');
     }
   }, [isLoading, isAuthenticated, router]);
+  
+  useEffect(() => {
+    // Скрываем глобальный лоадер когда страница готова
+    if (isAuthenticated && !isLoading) {
+      if (typeof window !== 'undefined' && (window as any).__hideGlobalLoader) {
+        (window as any).__hideGlobalLoader();
+      }
+      // Сохраняем текущий путь
+      saveLastPath('/chat');
+    }
+  }, [isAuthenticated, isLoading]);
 
   // Убираем автоматическое перенаправление - пользователи должны иметь возможность заходить в чат с мобильных
 

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -12,6 +12,7 @@ import MobileSearch from '@/frontend/components/MobileSearch';
 import AppShellSkeleton from '@/frontend/components/AppShellSkeleton';
 import { WithTooltip } from '@/frontend/components/WithTooltip';
 import type { Id } from '@/convex/_generated/dataModel';
+import { saveLastPath } from '@/frontend/lib/lastChat';
 
 export default function HomePage() {
   const { isAuthenticated, isLoading } = useConvexAuth();
@@ -26,13 +27,8 @@ export default function HomePage() {
     }
   }, [isLoading, isAuthenticated, router]);
 
-  // Автоматическое переключение на ПК версию при увеличении размера экрана
-  // Но только если пользователь уже находится на /home, не перенаправляем из чата
-  useEffect(() => {
-    if (!isLoading && isAuthenticated && mounted && !isMobile && window.location.pathname === '/home') {
-      router.push('/chat');
-    }
-  }, [isMobile, mounted, isLoading, isAuthenticated, router]);
+  // Убираем автоматическое перенаправление при изменении размера экрана
+  // Пользователь сам решит когда переходить
 
   const handleSelectThread = (threadId: Id<'threads'>) => {
     router.push(`/chat/${threadId}`);
@@ -41,6 +37,17 @@ export default function HomePage() {
   const handleNewChat = () => {
     router.push('/chat');
   };
+
+  useEffect(() => {
+    // Скрываем глобальный лоадер когда страница готова
+    if (mounted && isAuthenticated && !isLoading) {
+      if (typeof window !== 'undefined' && (window as any).__hideGlobalLoader) {
+        (window as any).__hideGlobalLoader();
+      }
+      // Сохраняем текущий путь
+      saveLastPath('/home');
+    }
+  }, [mounted, isAuthenticated, isLoading]);
 
   if (isLoading || !isAuthenticated) {
     return <AppShellSkeleton />;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -59,6 +59,25 @@ export default function RootLayout({
         }} />
       </head>
       <body suppressHydrationWarning className="antialiased font-sans font-mono">
+        {/* Глобальный прелоадер для предотвращения миганий */}
+        <div id="global-loader" className="fixed inset-0 bg-background z-[100] flex items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        </div>
+        <script dangerouslySetInnerHTML={{
+          __html: `
+            // Скрываем лоадер после инициализации приложения
+            if (typeof window !== 'undefined') {
+              window.__hideGlobalLoader = function() {
+                const loader = document.getElementById('global-loader');
+                if (loader) {
+                  loader.style.transition = 'opacity 200ms ease-out';
+                  loader.style.opacity = '0';
+                  setTimeout(() => loader.remove(), 200);
+                }
+              };
+            }
+          `
+        }} />
         <ClientScripts />
         <Suspense fallback={null}>
           <ConvexClientProvider>

--- a/frontend/components/ChatHistoryList.tsx
+++ b/frontend/components/ChatHistoryList.tsx
@@ -146,7 +146,6 @@ function ChatHistoryList({
 
   const handleThreadClick = useCallback(
     (threadId: Id<"threads">) => {
-      saveLastChatId(threadId);
       if (onSelectThread) {
         onSelectThread(threadId);
       } else {

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -38,7 +38,7 @@ import { useRecentFilesIntegration, addFileToRecent, addUploadedFileMetaToRecent
 import { getCompanyIcon } from '@/frontend/components/ui/provider-icons';
 import { useDebouncedCallback } from 'use-debounce';
 import { createImagePreview } from '@/frontend/lib/image';
-import { saveLastChatId } from '@/frontend/lib/lastChat';
+import { saveLastChatId, saveLastPath } from '@/frontend/lib/lastChat';
 
 // Helper to convert File objects to Base64 data URLs
 const fileToDataUrl = (file: File): Promise<string> => {
@@ -628,15 +628,12 @@ function PureChatInput({
       // 2. Если тред новый, обновляем состояние без редиректа
       if (!isConvexId(threadId)) {
         onThreadCreated?.(ensuredThreadId);
-        // Сохраняем ID нового чата сразу в localStorage
-        saveLastChatId(ensuredThreadId);
         // Обновляем URL плавно без перезагрузки страницы (только на клиенте)
         if (typeof window !== 'undefined') {
           window.history.replaceState(null, '', `/chat/${ensuredThreadId}`);
+          // Сохраняем новый путь
+          saveLastPath(`/chat/${ensuredThreadId}`);
         }
-      } else {
-        // Для существующих чатов тоже обновляем lastChatId
-        saveLastChatId(threadId);
       }
 
       // 3. Сохраняем текст сообщения в БД СРАЗУ, чтобы порядок (user → assistant) был корректным

--- a/frontend/components/MobileSearch.tsx
+++ b/frontend/components/MobileSearch.tsx
@@ -10,6 +10,7 @@ import { useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { useDebounce } from 'use-debounce';
 import type { Id } from '@/convex/_generated/dataModel';
+import { saveLastChatId } from '@/frontend/lib/lastChat';
 
 interface MobileSearchProps {
   isOpen: boolean;

--- a/frontend/hooks/useIsMobile.ts
+++ b/frontend/hooks/useIsMobile.ts
@@ -1,25 +1,40 @@
-import { useState, useLayoutEffect } from 'react';
+import { useState, useLayoutEffect, useEffect } from 'react';
 
 export function useIsMobile(breakpoint: number = 768) {
-  const [isMobile, setIsMobile] = useState(
-    typeof window !== 'undefined' ? window.innerWidth < breakpoint : false
-  );
-  const [mounted, setMounted] = useState(false);
+  // Инициализируем состояние один раз с правильным значением для SSR
+  const [state, setState] = useState(() => {
+    // На сервере всегда возвращаем немобильное состояние
+    if (typeof window === 'undefined') {
+      return { isMobile: false, mounted: false };
+    }
+    
+    // На клиенте сразу определяем правильное значение
+    return {
+      isMobile: window.innerWidth < breakpoint,
+      mounted: true
+    };
+  });
+
+  useEffect(() => {
+    // Если уже mounted, ничего не делаем
+    if (state.mounted) return;
+    
+    // Устанавливаем mounted только один раз
+    setState({
+      isMobile: window.innerWidth < breakpoint,
+      mounted: true
+    });
+  }, []);
 
   useLayoutEffect(() => {
     const checkMobile = () => {
       const isMobileDevice = window.innerWidth < breakpoint;
-      setIsMobile(isMobileDevice);
-      
-      if (!mounted) setMounted(true);
+      setState(prev => ({ ...prev, isMobile: isMobileDevice }));
     };
     
-    checkMobile();
-    
     window.addEventListener('resize', checkMobile);
-    
     return () => window.removeEventListener('resize', checkMobile);
-  }, [breakpoint, mounted]);
+  }, [breakpoint]);
 
-  return { isMobile: mounted ? isMobile : false, mounted };
+  return state;
 } 

--- a/frontend/lib/lastChat.ts
+++ b/frontend/lib/lastChat.ts
@@ -1,5 +1,8 @@
 export const LAST_CHAT_KEY = 'last-chat-id';
+export const LAST_PATH_KEY = 'last-path';
+export const SESSION_KEY = 'session-active';
 
+// Сохраняем ID последнего чата
 export function saveLastChatId(id: string) {
   try {
     localStorage.setItem(LAST_CHAT_KEY, id);
@@ -8,6 +11,7 @@ export function saveLastChatId(id: string) {
   }
 }
 
+// Получаем ID последнего чата
 export function getLastChatId(): string | null {
   try {
     return localStorage.getItem(LAST_CHAT_KEY);
@@ -16,9 +20,49 @@ export function getLastChatId(): string | null {
   }
 }
 
+// Очищаем ID последнего чата
 export function clearLastChatId() {
   try {
     localStorage.removeItem(LAST_CHAT_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+// Сохраняем последний путь
+export function saveLastPath(path: string) {
+  try {
+    localStorage.setItem(LAST_PATH_KEY, path);
+    // Отмечаем что сессия активна
+    sessionStorage.setItem(SESSION_KEY, 'true');
+  } catch {
+    // ignore
+  }
+}
+
+// Получаем последний путь
+export function getLastPath(): string | null {
+  try {
+    return localStorage.getItem(LAST_PATH_KEY);
+  } catch {
+    return null;
+  }
+}
+
+// Проверяем, это перезагрузка или новый заход
+export function isReload(): boolean {
+  try {
+    return sessionStorage.getItem(SESSION_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+// Очищаем данные сессии
+export function clearSession() {
+  try {
+    localStorage.removeItem(LAST_PATH_KEY);
+    sessionStorage.removeItem(SESSION_KEY);
   } catch {
     // ignore
   }

--- a/frontend/stores/AuthStore.ts
+++ b/frontend/stores/AuthStore.ts
@@ -2,7 +2,7 @@ import { User, GoogleAuthProvider, signInWithRedirect, signInWithPopup, signOut,
 import { create } from 'zustand';
 import { auth } from '@/firebase';
 import { useSettingsStore } from './SettingsStore';
-import { clearLastChatId } from '@/frontend/lib/lastChat';
+import { clearLastChatId, clearSession } from '@/frontend/lib/lastChat';
 import { useModelVisibilityStore } from './ModelVisibilityStore';
 
 interface AuthState {
@@ -43,6 +43,7 @@ export const useAuthStore = create<AuthState>((set) => {
       try {
         await signOut(auth);
         clearLastChatId();
+        clearSession();
         // Clear model visibility data to prevent data leakage between users
         useModelVisibilityStore.setState({
           favoriteModels: [],


### PR DESCRIPTION
- Fix multiple flash issues during page load by optimizing useIsMobile hook
- Add global loader to prevent visual flashing during app initialization
- Implement proper path tracking to maintain user's location on reload
- Separate reload behavior from new session navigation
- Users now stay on homepage when reloading homepage
- Users return to same chat when reloading chat pages
- New sessions properly redirect to homepage (mobile: /home, desktop: /chat)
- Remove automatic chat redirection that was interfering with user intent

Breaking changes:
- Modified localStorage structure to track last path and session state
- Changed root page behavior to respect user's current location