### PR TITLE
Fix global loader typing

### DIFF
--- a/app/chat/[...slug]/page.tsx
+++ b/app/chat/[...slug]/page.tsx
@@ -116,8 +116,8 @@ function CatchAllChatPageInner({ params }: { params: Promise<{ slug: string[] }>
     if (!isLoading) {
       setIsInitialLoad(false);
       // Скрываем глобальный лоадер когда страница готова
-      if (typeof window !== 'undefined' && (window as any).__hideGlobalLoader) {
-        (window as any).__hideGlobalLoader();
+      if (typeof window !== 'undefined' && window.__hideGlobalLoader) {
+        window.__hideGlobalLoader();
       }
     }
   }, [isLoading]);

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -21,8 +21,8 @@ export default function NewChatPage() {
   useEffect(() => {
     // Скрываем глобальный лоадер когда страница готова
     if (isAuthenticated && !isLoading) {
-      if (typeof window !== 'undefined' && (window as any).__hideGlobalLoader) {
-        (window as any).__hideGlobalLoader();
+      if (typeof window !== 'undefined' && window.__hideGlobalLoader) {
+        window.__hideGlobalLoader();
       }
       // Сохраняем текущий путь
       saveLastPath('/chat');

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -41,8 +41,8 @@ export default function HomePage() {
   useEffect(() => {
     // Скрываем глобальный лоадер когда страница готова
     if (mounted && isAuthenticated && !isLoading) {
-      if (typeof window !== 'undefined' && (window as any).__hideGlobalLoader) {
-        (window as any).__hideGlobalLoader();
+      if (typeof window !== 'undefined' && window.__hideGlobalLoader) {
+        window.__hideGlobalLoader();
       }
       // Сохраняем текущий путь
       saveLastPath('/home');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuthStore } from '@/frontend/stores/AuthStore';
 import { Button } from '@/frontend/components/ui/button';
-import { getLastChatId, getLastPath, isReload, saveLastPath } from '@/frontend/lib/lastChat';
+import { getLastPath, isReload, saveLastPath } from '@/frontend/lib/lastChat';
 import AppShellSkeleton from '@/frontend/components/AppShellSkeleton';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 
@@ -22,8 +22,8 @@ export default function Page() {
       setIsInitialized(true);
       
       // Если пользователь не авторизован, скрываем глобальный лоадер
-      if (!user && typeof window !== 'undefined' && (window as any).__hideGlobalLoader) {
-        (window as any).__hideGlobalLoader();
+      if (!user && typeof window !== 'undefined' && window.__hideGlobalLoader) {
+        window.__hideGlobalLoader();
       }
     }
   }, [mounted, loading, isInitialized, user]);

--- a/frontend/components/ChatHistoryDrawer.tsx
+++ b/frontend/components/ChatHistoryDrawer.tsx
@@ -145,6 +145,8 @@ function ChatHistoryDrawerComponent({
   const [longPressThreadId, setLongPressThreadId] =
     useState<Id<"threads"> | null>(null);
   const [selectedThreadIndex, setSelectedThreadIndex] = useState<number>(-1);
+  // Tracks whether navigation was triggered via keyboard arrows
+  const autoScrollRef = useRef(false);
   const [mobileMenuThreadId, setMobileMenuThreadId] =
     useState<Id<"threads"> | null>(null);
   const itemRefs = useRef<Map<number, HTMLDivElement | null>>(new Map());
@@ -186,6 +188,7 @@ function ChatHistoryDrawerComponent({
           setLongPressThreadId(null);
           setSelectedThreadIndex(-1);
           setMobileMenuThreadId(null);
+          autoScrollRef.current = false;
         }
       }
     },
@@ -311,11 +314,13 @@ function ChatHistoryDrawerComponent({
         case "ArrowDown":
           e.preventDefault();
           setHoveredThreadId(null);
+          autoScrollRef.current = true;
           setSelectedThreadIndex((prev) => (prev < allThreadsFlat.length - 1 ? prev + 1 : prev));
           break;
         case "ArrowUp":
           e.preventDefault();
           setHoveredThreadId(null);
+          autoScrollRef.current = true;
           setSelectedThreadIndex((prev) => (prev > 0 ? prev - 1 : prev));
           break;
         case "Enter":
@@ -341,7 +346,7 @@ function ChatHistoryDrawerComponent({
   }, [isOpen, isMobile, handleKeyDown]);
 
   useEffect(() => {
-    if (selectedThreadIndex >= 0 && !isMobile) {
+    if (selectedThreadIndex >= 0 && !isMobile && autoScrollRef.current) {
       const node = itemRefs.current.get(selectedThreadIndex);
       node?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
@@ -381,6 +386,7 @@ function ChatHistoryDrawerComponent({
         onMouseEnter={() => {
           setHoveredThreadId(thread._id);
           if (!isMobile) {
+            autoScrollRef.current = false;
             setSelectedThreadIndex(threadIndex);
           }
           // Сбрасываем состояние удаления при наведении на другой элемент

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  interface Window {
+    __hideGlobalLoader?: () => void;
+  }
+}


### PR DESCRIPTION
## Summary
- address lint failures by replacing `window as any` type assertions
- ensure auto-scroll only triggers when navigating chat history via arrow keys
- export global `Window` interface for the loader helper

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Client created with undefined deployment address)*

------
https://chatgpt.com/codex/tasks/task_e_685423dbd6c8832bb696545cb79e2649