### PR TITLE
Fix attachment upload flow

### DIFF
--- a/frontend/components/AttachmentsBar.tsx
+++ b/frontend/components/AttachmentsBar.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import { Loader2 } from 'lucide-react';
 import { useAttachmentsStore } from '../stores/AttachmentsStore';
 import AddActionsDropdown from './AddActionsDropdown';
 import FilePreview from './FilePreview';
@@ -11,6 +12,9 @@ interface AttachmentsBarProps {
 
 export default function AttachmentsBar({ mode = 'full', messageCount = 0 }: AttachmentsBarProps) {
   const { attachments, add, remove } = useAttachmentsStore();
+  const anyUploading = attachments.some(
+    (a) => !a.remote && (a as any).isUploading
+  );
   const inputRef = useRef<HTMLInputElement>(null);
 
   // В компактном режиме показываем новое выпадающее меню
@@ -24,7 +28,7 @@ export default function AttachmentsBar({ mode = 'full', messageCount = 0 }: Atta
 
   // В полном режиме показываем все файлы
   return (
-    <div className="flex items-center gap-2 w-full overflow-x-auto pb-2">
+    <div className="relative flex items-center gap-2 w-full overflow-x-auto pb-2">
       {attachments.map((f) => (
         <FilePreview
           key={f.id}
@@ -33,6 +37,11 @@ export default function AttachmentsBar({ mode = 'full', messageCount = 0 }: Atta
           showPreview={true}
         />
       ))}
+      {anyUploading && (
+        <div className="absolute inset-0 flex items-center justify-center bg-background/80 backdrop-blur-sm pointer-events-none rounded-md">
+          <Loader2 className="w-5 h-5 text-foreground animate-spin" />
+        </div>
+      )}
       <input
         ref={inputRef}
         type="file"

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -601,10 +601,9 @@ function PureChatInput({
       finalMessage = `> ${currentQuote.text.replace(/\n/g, '\n> ')}\n\n${currentInput.trim()}`;
     }
 
-    // Reset UI early
+    // Reset UI early but keep attachments until they finish uploading
     setInput('');
     clearQuote();
-    clear(); // Очищаем файлы и вложения после отправки
     adjustHeight(true);
 
     try {
@@ -838,6 +837,9 @@ function PureChatInput({
           }
         });
       }
+
+      // Clear attachments only after successful upload
+      clear();
 
       // 11. UI обновится автоматически через useConvexMessages после добавления в DB
 


### PR DESCRIPTION
## Summary
- keep attachments visible while uploading in ChatInput
- show an uploading overlay in AttachmentsBar

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6854377b116c832b843123a6f893cdad