### PR TITLE
Fix new chat last chat id

### DIFF
--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -654,6 +654,8 @@ function PureChatInput({
           window.history.replaceState(null, '', `/chat/${ensuredThreadId}`);
           // Сохраняем новый путь
           saveLastPath(`/chat/${ensuredThreadId}`);
+          // Также обновляем последний выбранный чат
+          saveLastChatId(ensuredThreadId);
         }
       }
 


### PR DESCRIPTION
## Summary
- update last chat state when creating a new thread

## Testing
- `pnpm lint`
- `pnpm vitest --run` *(fails: Cannot find module '@storybook/addon-vitest/vitest-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68545af435d0832bb9bdcdb2dda398ca