### PR TITLE
Fix mobile text selection interfering with message controls

### DIFF
--- a/frontend/components/Message.tsx
+++ b/frontend/components/Message.tsx
@@ -70,6 +70,10 @@ function PureMessage({
   const handleMobileMessageClick = () => {
     if (isMobile && !isWelcome) {
       setMobileControlsVisible(!mobileControlsVisible);
+      const selection = window.getSelection();
+      if (selection && selection.rangeCount > 0) {
+        selection.removeAllRanges();
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- clear any active text selections when showing mobile message controls

## Testing
- `pnpm lint`
- `pnpm vitest` *(fails: Cannot find module '@storybook/addon-vitest/vitest-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68545f0237fc832b89273ae8b2933c2a