### PR TITLE
Fix chat thread reuse

### DIFF
--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -566,14 +566,16 @@ function PureChatInput({
     const initialText = thread?.draft ?? '';
     setInput(initialText);
     adjustHeight();
-    
-    // ИСПРАВЛЕНИЕ: Сбрасываем sessionThreadId при смене треда
+  }, [threadId, thread]);
+
+  // Track the created thread only when the incoming threadId changes
+  useEffect(() => {
     if (isConvexId(threadId)) {
       setSessionThreadId(threadId);
     } else {
       setSessionThreadId(null);
     }
-  }, [threadId, thread, setInput, adjustHeight]);
+  }, [threadId]);
 
   // Debounced draft saver to reduce server load
   const debouncedSaveDraft = useDebouncedCallback((draftText: string) => {


### PR DESCRIPTION
## Summary
- stabilize session thread tracking in ChatInput by only resetting when thread changes

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68547ee87454832b88e1bb185fcd2b39