### PR TITLE
Fix redirect logic on initial login

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,8 +29,8 @@ export default function Page() {
         console.log('Redirecting to last path:', lastPath);
         router.replace(lastPath);
       }
-      // Если есть последний чат, переходим к нему
-      else if (lastChatId) {
+      // Если это именно перезагрузка и есть последний чат, переходим к нему
+      else if (isReload() && lastChatId) {
         console.log('Redirecting to last chat:', lastChatId);
         router.replace(`/chat/${lastChatId}`);
       }


### PR DESCRIPTION
## Summary
- ensure last chat redirect only triggers on reload
- keep device-specific home page for new sessions

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6855b431fd78832ba7f09540993053e1