### PR TITLE
Fix Gemini API error and deduplicate messages

### DIFF
--- a/app/api/llm-google/route.ts
+++ b/app/api/llm-google/route.ts
@@ -180,6 +180,13 @@ export async function POST(req: NextRequest) {
       }
     }
 
+    if (contents.length === 0) {
+      return new NextResponse(
+        JSON.stringify({ error: 'No message content provided' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
     // Конфигурация для генерации с поддержкой thinking и search
     const config = {
       model: modelConfig.modelId,

--- a/frontend/components/ChatView.tsx
+++ b/frontend/components/ChatView.tsx
@@ -191,8 +191,16 @@ function ChatView({ threadId, thread, initialMessages, showNavBars }: ChatViewPr
     const allMessages = [...updatedMessages, ...missingConvexMessages]
       .sort((a, b) => getTime(a.createdAt) - getTime(b.createdAt));
 
-    
-    return allMessages;
+    const deduped: typeof allMessages = [];
+    const seen = new Set<string>();
+    for (const msg of allMessages) {
+      if (!seen.has(msg.id)) {
+        seen.add(msg.id);
+        deduped.push(msg);
+      }
+    }
+
+    return deduped;
   }, [messages, convexMessages]);
 
   // Функция для отслеживания видимых сообщений


### PR DESCRIPTION
## Summary
- handle empty Gemini request contents gracefully
- deduplicate messages when merging with Convex

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6855b76c4804832ba59f4b2b1b8d3878