### PR TITLE
Fix unused variables causing lint errors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuthStore } from '@/frontend/stores/AuthStore';
 import { Button } from '@/frontend/components/ui/button';
-import { getLastChatId, getLastPath, isReload } from '@/frontend/lib/lastChat';
+import { getLastPath, isReload } from '@/frontend/lib/lastChat';
 import AppShellSkeleton from '@/frontend/components/AppShellSkeleton';
 import { useIsMobile } from '@/frontend/hooks/useIsMobile';
 
@@ -21,7 +21,6 @@ export default function Page() {
       console.log('User authenticated, redirecting...');
       hasRedirectedRef.current = true;
       
-      const lastChatId = getLastChatId();
       const lastPath = getLastPath();
       
       // Если это перезагрузка и есть последний путь, переходим туда


### PR DESCRIPTION
## Summary
- remove unused `useState` import
- remove leftover variable `lastChatId`

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6855c61eb228832ba8bd1adfef61c666