### PR TITLE
Add OpenAI o3 model support

### DIFF
--- a/app/api/llm/route.ts
+++ b/app/api/llm/route.ts
@@ -76,9 +76,9 @@ export async function POST(req: NextRequest) {
         }
         break;
       case 'openai':
-        // Применяем reasoningEffort только для o1/o4 моделей (моделей с reasoning)
+        // Применяем reasoningEffort только для o1/o3/o4 моделей (моделей с reasoning)
         const openaiConfig: { reasoningEffort?: "low" | "medium" | "high" } = {};
-        if (reasoningEffort && model === 'o4-mini') {
+        if (reasoningEffort && ['o4-mini', 'o3'].includes(model)) {
           openaiConfig.reasoningEffort = reasoningEffort;
         }
         aiModel = createOpenAI({ apiKey })(modelConfig.modelId, openaiConfig);

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -139,7 +139,7 @@ const PureChatModelDropdown = ({ messageCount = 0 }: ChatModelDropdownProps) => 
   const [isReasoningEffortOpen, setIsReasoningEffortOpen] = useState(false);
 
   const currentModelConfig = getModelConfigFromStore();
-  const showReasoningEffortButton = selectedModel === 'o4-mini';
+  const showReasoningEffortButton = ['o4-mini', 'o3'].includes(selectedModel);
   const showWebSearchButton = supportsWebSearch();
 
   const reasoningEfforts: ReasoningEffort[] = ['high', 'medium', 'low'];

--- a/frontend/components/SettingsDrawer.tsx
+++ b/frontend/components/SettingsDrawer.tsx
@@ -718,7 +718,7 @@ const APIKeysTab = memo(() => {
             <ApiKeyField
               id="openai"
               label="OpenAI API Key"
-              models={['GPT-4o', 'GPT-4.1-mini', 'GPT-4.1', 'GPT-4.1-nano', 'o4-mini']}
+              models={['GPT-4o', 'GPT-4.1-mini', 'GPT-4.1', 'GPT-4.1-nano', 'o4-mini', 'o3']}
               linkUrl="https://platform.openai.com/settings/organization/api-keys"
               placeholder="sk-..."
               register={register}

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -10,6 +10,7 @@ export const AI_MODELS = [
   'GPT-4.1',
   'GPT-4.1-nano',
   'o4-mini',
+  'o3',
   'Meta Llama 4 Scout 17B',
   'Meta Llama 4 Maverick 17B',
   'DeepSeek R1 Distill Llama 70B',
@@ -69,6 +70,12 @@ export const MODEL_CONFIGS: Record<AIModel, ModelConfig> = {
   },
   'o4-mini': {
     modelId: 'o4-mini',
+    provider: 'openai',
+    company: 'OpenAI',
+    reasoningEffort: 'medium',
+  },
+  'o3': {
+    modelId: 'o3',
     provider: 'openai',
     company: 'OpenAI',
     reasoningEffort: 'medium',


### PR DESCRIPTION
## Summary
- add `o3` to available AI models
- allow reasoning effort for `o3` in API
- show reasoning options when `o3` is selected
- include `o3` in Settings drawer

## Testing
- `pnpm lint`
- `pnpm exec vitest run` *(fails: Cannot find module '@storybook/addon-vitest/vitest-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6855c8221690832baaacd4379096697f