### PR TITLE
Fix large left margin on some mobile devices

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -673,13 +673,61 @@ code[class*="language-"] {
   pointer-events: auto;
 }
 
-/* Принудительно поднимаем drawer настроек */
+/* Унифицированные стили для мобильного drawer настроек */
 [data-vaul-drawer] {
-  margin-bottom: 20px !important;
+  margin: 0 !important;
+  margin-bottom: 16px !important;
+  margin-left: 16px !important;
+  margin-right: 16px !important;
+  /* Принудительно убираем все отступы которые могут добавляться */
+  padding: 0 !important;
 }
 
 [data-vaul-drawer][data-vaul-drawer-direction="bottom"] {
-  bottom: 20px !important;
+  bottom: 16px !important;
+  left: 16px !important;
+  right: 16px !important;
+  /* Принудительно задаем ширину */
+  width: calc(100vw - 32px) !important;
+  max-width: calc(100vw - 32px) !important;
+  min-width: calc(100vw - 32px) !important;
+  /* Убираем любые margin которые могут влиять */
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+/* Унифицированная высота и поведение drawer */
+@media (max-width: 768px) {
+  [data-vaul-drawer-content] {
+    height: 80vh !important;
+    max-height: 600px !important;
+    border-radius: 16px 16px 0 0 !important;
+    /* Фиксированные отступы для всех устройств */
+    padding-bottom: 24px !important;
+    /* Убираем различия в safe-area */
+    padding-bottom: max(24px, env(safe-area-inset-bottom, 0px)) !important;
+    /* Принудительно убираем все отступы */
+    margin: 0 !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    /* Точно позиционируем drawer */
+    position: fixed !important;
+    left: 16px !important;
+    right: 16px !important;
+    width: calc(100vw - 32px) !important;
+  }
+  
+  /* Стабильное перекрытие контента */
+  .mobile-settings-active {
+    transform: translateY(20px) scale(0.95) !important;
+    border-radius: 12px !important;
+  }
+  
+  /* Дополнительное правило для элементов внутри drawer */
+  [data-vaul-drawer-content] > * {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
 }
 
 

--- a/frontend/components/SettingsDrawer.tsx
+++ b/frontend/components/SettingsDrawer.tsx
@@ -153,7 +153,8 @@ const ContentComponent = memo(function ContentComponent({
 ContentComponent.displayName = 'ContentComponent';
 
 const SettingsDrawerComponent = ({ children, isOpen, setIsOpen }: SettingsDrawerProps) => {
-  const { isMobile, mounted } = useIsMobile(900);
+  // Унифицированный breakpoint для всех мобильных устройств
+  const { isMobile, mounted } = useIsMobile(768);
   const [activeTab, setActiveTab] = useState("customization");
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -164,7 +165,7 @@ const SettingsDrawerComponent = ({ children, isOpen, setIsOpen }: SettingsDrawer
     }
   }, [setIsOpen, setActiveTab]);
 
-  // Отдельный обработчик для управления мобильным эффектом
+  // Унифицированный обработчик мобильного эффекта для всех устройств
   const handleMobileEffect = useCallback((shouldApply: boolean) => {
     if (!isMobile) return;
     
@@ -173,13 +174,14 @@ const SettingsDrawerComponent = ({ children, isOpen, setIsOpen }: SettingsDrawer
 
     if (shouldApply) {
       mainContent.classList.add('mobile-settings-active');
+      // Применяем унифицированные значения
+      (mainContent as any).style.transform = 'translateY(20px) scale(0.95)';
+      (mainContent as any).style.borderRadius = '12px';
     } else {
       mainContent.classList.remove('mobile-settings-active');
-      // Сбрасываем inline стили
-      if (mainContent.style) {
-        (mainContent as any).style.transform = '';
-        (mainContent as any).style.borderRadius = '';
-      }
+      // Полностью сбрасываем inline стили
+      (mainContent as any).style.transform = '';
+      (mainContent as any).style.borderRadius = '';
     }
   }, [isMobile]);
 
@@ -261,14 +263,15 @@ const SettingsDrawerComponent = ({ children, isOpen, setIsOpen }: SettingsDrawer
           dismissible={true}
           modal={true}
           onDrag={(event, percentageDragged) => {
-            // Синхронизируем анимацию заднего фона с процентом перетаскивания
+            // Унифицированная анимация для всех мобильных устройств
             if (isMobile && percentageDragged > 0) {
               const mainContent = document.querySelector('.main-content') as HTMLElement;
               if (mainContent && mainContent.style) {
                 const progress = Math.max(0, 1 - percentageDragged);
-                const translateY = 30 * progress;
+                // Фиксированные значения для одинакового поведения на всех устройствах
+                const translateY = 20 * progress;
                 const scale = 0.95 + (0.05 * (1 - progress));
-                const borderRadius = 15 * progress;
+                const borderRadius = 12 * progress;
                 
                 (mainContent as any).style.transform = `translateY(${translateY}px) scale(${scale})`;
                 (mainContent as any).style.borderRadius = `${borderRadius}px`;
@@ -283,7 +286,7 @@ const SettingsDrawerComponent = ({ children, isOpen, setIsOpen }: SettingsDrawer
           <DrawerTrigger asChild>
             {children}
           </DrawerTrigger>
-          <DrawerContent className="max-h-[calc(50dvh-15px)] flex flex-col w-full p-0">
+          <DrawerContent className="h-[80vh] max-h-[600px] flex flex-col w-full p-0 rounded-t-2xl">
           {/* Pull handle */}
           <div className="flex justify-center pt-2 pb-1 flex-shrink-0">
             <div className="w-12 h-1 bg-muted-foreground/30 rounded-full" />
@@ -300,7 +303,7 @@ const SettingsDrawerComponent = ({ children, isOpen, setIsOpen }: SettingsDrawer
           </div>
           
           {/* Content area with proper scrolling */}
-          <div className="flex-1 min-h-0 px-4 pb-safe overflow-y-auto scrollbar-none enhanced-scroll">
+          <div className="flex-1 min-h-0 px-4 pb-6 overflow-y-auto scrollbar-none enhanced-scroll">
             <ContentComponent
               activeTab={activeTab}
               setActiveTab={setActiveTab}


### PR DESCRIPTION
- Removed mx-4 from DrawerContent to prevent extra margins
- Added fixed positioning with left: 16px, right: 16px for all devices
- Force removed all margin/padding that could cause inconsistencies
- Added rules for child elements to ensure 100% width
- Unified drawer width calculation across all mobile devices