### PR TITLE
Fix build by closing thread wrapper

### DIFF
--- a/frontend/components/ChatHistoryDrawer.tsx
+++ b/frontend/components/ChatHistoryDrawer.tsx
@@ -765,6 +765,7 @@ function ChatHistoryDrawerComponent({
               )}
             </>
           )}
+          </div>
         </div>
       </div>
     ),


### PR DESCRIPTION
## Summary
- fix markup in `ChatHistoryDrawer` by closing the outer wrapper for thread items

## Testing
- `pnpm lint`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6855f4a9357c832bb1264502c6b91c45