### PR TITLE
Fix disappearing messages after multiple replies

### DIFF
--- a/frontend/components/ChatView.tsx
+++ b/frontend/components/ChatView.tsx
@@ -316,7 +316,7 @@ function ChatView({ threadId, thread, initialMessages, showNavBars }: ChatViewPr
       // Remember last active chat for automatic restoration on reload
       saveLastChatId(threadId);
     }
-  }, [threadId, setInput, clearQuote, clearAttachments, setMessages, initialMessages]);
+  }, [threadId]);
 
   // Persist unsent messages and input as a draft
   useEffect(() => {


### PR DESCRIPTION
## Summary
- retain latest messages while Convex queries load
- prevent effect from clearing messages when query updates

## Testing
- `pnpm lint`
- `pnpm build` *(fails: ELIFECYCLE)*

------
https://chatgpt.com/codex/tasks/task_e_685607dc9d24832b9b9bd864e610c079