### PR TITLE
Fix drawer close animation state

### DIFF
--- a/frontend/components/ChatHistoryDrawer.tsx
+++ b/frontend/components/ChatHistoryDrawer.tsx
@@ -179,26 +179,35 @@ function ChatHistoryDrawerComponent({
   const togglePin = useMutation(api.threads.togglePin);
   const createShareLink = useMutation(api.threads.createShareLink);
 
+  const resetDrawerState = useCallback(() => {
+    setRawQuery("");
+    setEditingThreadId(null);
+    setEditingTitle("");
+    setDeletingThreadId(null);
+    setHoveredThreadId(null);
+    setSelectedThreadIndex(-1);
+    setMobileMenuThreadId(null);
+    allowAutoScrollRef.current = false;
+    lastKeyPressRef.current = 0;
+    pendingScrollRef.current = false;
+  }, []);
+
   const handleOpenChange = useCallback(
     (open: boolean) => {
       if (!open || isOpen !== open) {
         setIsOpen(open);
-                  if (!open) {
-            setRawQuery("");
-            setEditingThreadId(null);
-            setEditingTitle("");
-            setDeletingThreadId(null);
-            setHoveredThreadId(null);
-            setSelectedThreadIndex(-1); // Сброс только при закрытии диалога
-            setMobileMenuThreadId(null);
-            allowAutoScrollRef.current = false;
-            lastKeyPressRef.current = 0;
-            pendingScrollRef.current = false;
-            // Не сбрасываем скролл позицию, чтобы пользователь мог вернуться к тому же месту
-          }
       }
     },
     [setIsOpen, isOpen],
+  );
+
+  const handleAnimationEnd = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        resetDrawerState();
+      }
+    },
+    [resetDrawerState],
   );
 
   // ---------------- Memoized, grouped & sorted thread lists ----------
@@ -858,7 +867,7 @@ function ChatHistoryDrawerComponent({
 
   if (isMobile) {
     const main = (
-      <Drawer open={isOpen} onOpenChange={handleOpenChange}>
+      <Drawer open={isOpen} onOpenChange={handleOpenChange} onAnimationEnd={handleAnimationEnd}>
         <DrawerTrigger asChild>{children}</DrawerTrigger>
         <DrawerContent className="max-h-[95vh] flex flex-col w-full">
           <div className="flex h-full max-h-[90vh] flex-col">
@@ -957,7 +966,7 @@ function ChatHistoryDrawerComponent({
   }
 
   const desktop = (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange} onAnimationEnd={handleAnimationEnd}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className={cn(
         "w-[85vw] sm:max-w-none max-w-none h-[80vh] p-0 [&>button]:top-2 [&>button]:right-2 overflow-hidden focus:outline-none grid-rows-none rounded-3xl",

--- a/frontend/components/SettingsDrawer.tsx
+++ b/frontend/components/SettingsDrawer.tsx
@@ -158,12 +158,19 @@ const SettingsDrawerComponent = ({ children, isOpen, setIsOpen }: SettingsDrawer
   const [activeTab, setActiveTab] = useState("customization");
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  const resetDrawerState = useCallback(() => {
+    setActiveTab('customization');
+  }, []);
+
   const handleOpenChange = useCallback((open: boolean) => {
     setIsOpen(open);
+  }, [setIsOpen]);
+
+  const handleAnimationEnd = useCallback((open: boolean) => {
     if (!open) {
-      setActiveTab('customization');
+      resetDrawerState();
     }
-  }, [setIsOpen, setActiveTab]);
+  }, [resetDrawerState]);
 
   // Унифицированный обработчик мобильного эффекта для всех устройств
   const handleMobileEffect = useCallback((shouldApply: boolean) => {
@@ -256,9 +263,10 @@ const SettingsDrawerComponent = ({ children, isOpen, setIsOpen }: SettingsDrawer
           isOpen && "active"
         )} onClick={() => handleOpenChange(false)} />
         
-              <Drawer 
-          open={isOpen} 
+      <Drawer
+          open={isOpen}
           onOpenChange={handleOpenChange}
+          onAnimationEnd={handleAnimationEnd}
           shouldScaleBackground={false}
           dismissible={true}
           modal={true}
@@ -320,7 +328,7 @@ const SettingsDrawerComponent = ({ children, isOpen, setIsOpen }: SettingsDrawer
   }
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange} onAnimationEnd={handleAnimationEnd}>
       <DialogTrigger asChild>
         {children}
       </DialogTrigger>


### PR DESCRIPTION
## Summary
- ensure drawer state resets after close animation
- pass onAnimationEnd to ChatHistoryDrawer
- pass onAnimationEnd to SettingsDrawer

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_685675ffc2dc832b964e9bcc22feaea0