### PR TITLE
Fix response body reuse error on Google model search

### DIFF
--- a/frontend/components/MessageEditor.tsx
+++ b/frontend/components/MessageEditor.tsx
@@ -171,7 +171,8 @@ export default function MessageEditor({
     }),
     onResponse: async (response) => {
       try {
-        const payload = await response.json();
+        // Clone the response to avoid consuming the body used by the hook
+        const payload = await response.clone().json();
 
         if (response.ok) {
           const { title } = payload;

--- a/frontend/hooks/useMessageSummary.ts
+++ b/frontend/hooks/useMessageSummary.ts
@@ -24,7 +24,10 @@ export const useMessageSummary = () => {
     headers: googleApiKey ? { 'X-Google-API-Key': googleApiKey } : undefined,
     onResponse: async (response) => {
       try {
-        const payload: MessageSummaryPayload = await response.json();
+        // Clone response so AI SDK can continue streaming without errors
+        const payload: MessageSummaryPayload = await response
+          .clone()
+          .json();
 
         if (response.ok) {
           const { title, isTitle, threadId } = payload;


### PR DESCRIPTION
## Summary
- clone the API response before parsing JSON in `useMessageSummary`
- clone the API response before parsing JSON in `MessageEditor`

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6866a60747a4832b8b8a0c67ac01c8b6