### PR TITLE
Fix Google search for Gemini 2.5

### DIFF
--- a/app/api/llm-google/route.ts
+++ b/app/api/llm-google/route.ts
@@ -231,16 +231,14 @@ export async function POST(req: NextRequest) {
       config: {
         ...generationConfig,
         ...thinkingConfig,
-        // Включаем search grounding если запрошено
+        // Включаем Search Grounding для моделей Gemini 2.5
         ...(search && {
-          tools: [{
-            googleSearchRetrieval: {
-              dynamicRetrievalConfig: {
-                mode: "MODE_DYNAMIC",
-                dynamicThreshold: 0.3,
-              }
+          tools: [
+            {
+              // новое API вместо устаревшего googleSearchRetrieval
+              googleSearch: {}
             }
-          }]
+          ]
         })
       },
       contents,


### PR DESCRIPTION
## Summary
- switch to `googleSearch` tool instead of legacy `googleSearchRetrieval`

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68684765f940832b8407fd1209b14089