### PR TITLE
Fix preview for recent images

### DIFF
--- a/frontend/components/RecentFilesDropdown.tsx
+++ b/frontend/components/RecentFilesDropdown.tsx
@@ -144,8 +144,7 @@ export default function RecentFilesDropdown({ children, onFileSelect, messageCou
           name: recentFile.name,
           type: recentFile.type,
           size: recentFile.size,
-          preview: previewUrl,
-          remote: true,
+          preview: previewUrl || recentFile.preview || '',
         });
         
         // Обновляем время последнего использования

--- a/frontend/components/mobile/MobileAddActionsDrawer.tsx
+++ b/frontend/components/mobile/MobileAddActionsDrawer.tsx
@@ -173,8 +173,7 @@ export default function MobileAddActionsDrawer({
           name: file.name,
           type: file.type,
           size: file.size,
-          preview: previewUrl,
-          remote: true,
+          preview: previewUrl || file.preview || '',
         });
         
         const updated = recentFiles.map(f => 

--- a/frontend/stores/AttachmentsStore.ts
+++ b/frontend/stores/AttachmentsStore.ts
@@ -55,22 +55,33 @@ export const useAttachmentsStore = create<AttachmentState>((set) => ({
       ],
     })),
   addRemote: (info) =>
-    set((state) => ({
-      attachments: [
-        ...state.attachments,
-        {
-          id: uuid(),
-          preview: info.preview || '', // Пустая строка для не-изображений
-          name: info.name.length > 24 ? info.name.slice(0, 21) + '...' : info.name,
-          ext: info.name.split('.').pop() ?? '',
-          type: info.type,
-          size: info.size,
-          storageId: info.storageId,
-          previewId: info.previewId,
-          remote: true,
-        } as RemoteAttachment,
-      ],
-    })),
+    set((state) => {
+      // Use provided preview or fall back to API path when available
+      const previewUrl =
+        info.preview ||
+        (info.previewId
+          ? `/api/files/${info.previewId}`
+          : info.storageId
+            ? `/api/files/${info.storageId}`
+            : '');
+
+      return {
+        attachments: [
+          ...state.attachments,
+          {
+            id: uuid(),
+            preview: previewUrl,
+            name: info.name.length > 24 ? info.name.slice(0, 21) + '...' : info.name,
+            ext: info.name.split('.').pop() ?? '',
+            type: info.type,
+            size: info.size,
+            storageId: info.storageId,
+            previewId: info.previewId,
+            remote: true,
+          } as RemoteAttachment,
+        ],
+      };
+    }),
   remove: (id) => set((state) => {
     const attachment = state.attachments.find(a => a.id === id);
     if (attachment) {


### PR DESCRIPTION
## Summary
- ensure remote attachments always have a preview URL
- use stored preview URL when reattaching recent files (desktop & mobile)

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868fba686a4832bbc19386051dba5d8