### PR TITLE
Fix preview fallback for attachments

### DIFF
--- a/frontend/stores/AttachmentsStore.ts
+++ b/frontend/stores/AttachmentsStore.ts
@@ -57,8 +57,10 @@ export const useAttachmentsStore = create<AttachmentState>((set) => ({
   addRemote: (info) =>
     set((state) => {
       // Use provided preview or fall back to API path when available
+      // Prefer explicitly provided preview. Fallback to API file URLs only when
+      // preview is undefined or null.
       const previewUrl =
-        info.preview ||
+        info.preview ??
         (info.previewId
           ? `/api/files/${info.previewId}`
           : info.storageId


### PR DESCRIPTION
## Summary
- ensure empty preview strings are preserved when adding remote attachments

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686900788c34832b9152939a9e6b2f65