### PR TITLE
Fix send button disable logic

### DIFF
--- a/frontend/components/chat-input/ChatInput.tsx
+++ b/frontend/components/chat-input/ChatInput.tsx
@@ -185,7 +185,12 @@ function PureChatInput({
   }, [isImageGenerationMode, setImageGenerationMode, textareaRef]);
 
   const canChat = keysLoading || readyToChat;
-  const isDisabled = !input.trim() || status === 'streaming' || status === 'submitted' || isSubmitting || !readyToChat;
+  const isDisabled =
+    !input.trim() ||
+    status === 'streaming' ||
+    status === 'submitted' ||
+    isSubmitting ||
+    !canChat;
 
   return (
     <div className="w-full flex justify-center pb-safe mobile-keyboard-fix">


### PR DESCRIPTION
## Summary
- allow sending messages while keys load by using `canChat` consistently

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6869027e5d90832bb70de3ebe84c183a