### PR TITLE
Fix remote attachment preview fallback

### DIFF
--- a/frontend/components/RecentFilesDropdown.tsx
+++ b/frontend/components/RecentFilesDropdown.tsx
@@ -144,7 +144,9 @@ export default function RecentFilesDropdown({ children, onFileSelect, messageCou
           name: recentFile.name,
           type: recentFile.type,
           size: recentFile.size,
-          preview: previewUrl || recentFile.preview || '',
+          // Pass undefined when no preview is available so the store can
+          // generate a fallback URL from previewId or storageId.
+          preview: previewUrl || recentFile.preview,
         });
         
         // Обновляем время последнего использования

--- a/frontend/components/mobile/MobileAddActionsDrawer.tsx
+++ b/frontend/components/mobile/MobileAddActionsDrawer.tsx
@@ -173,7 +173,9 @@ export default function MobileAddActionsDrawer({
           name: file.name,
           type: file.type,
           size: file.size,
-          preview: previewUrl || file.preview || '',
+          // Pass undefined when no preview is available so store can
+          // generate a fallback URL from previewId or storageId.
+          preview: previewUrl || file.preview,
         });
         
         const updated = recentFiles.map(f => 

--- a/frontend/stores/AttachmentsStore.ts
+++ b/frontend/stores/AttachmentsStore.ts
@@ -56,16 +56,16 @@ export const useAttachmentsStore = create<AttachmentState>((set) => ({
     })),
   addRemote: (info) =>
     set((state) => {
-      // Use provided preview or fall back to API path when available
-      // Prefer explicitly provided preview. Fallback to API file URLs only when
-      // preview is undefined or null.
+      // Use provided preview when it's a non-empty string, otherwise
+      // construct a preview URL from previewId or storageId.
       const previewUrl =
-        info.preview ??
-        (info.previewId
-          ? `/api/files/${info.previewId}`
-          : info.storageId
-            ? `/api/files/${info.storageId}`
-            : '');
+        (typeof info.preview === 'string' && info.preview.trim() !== '')
+          ? info.preview
+          : info.previewId
+            ? `/api/files/${info.previewId}`
+            : info.storageId
+              ? `/api/files/${info.storageId}`
+              : '';
 
       return {
         attachments: [


### PR DESCRIPTION
## Summary
- ensure preview fallback runs when preview is an empty string
- avoid passing empty preview strings from UI components

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686903b0463c832bb11098a0cb45fc82