### PR TITLE
Fix addRemote usage

### DIFF
--- a/frontend/components/RecentFilesDropdown.tsx
+++ b/frontend/components/RecentFilesDropdown.tsx
@@ -145,6 +145,7 @@ export default function RecentFilesDropdown({ children, onFileSelect, messageCou
           type: recentFile.type,
           size: recentFile.size,
           preview: previewUrl || recentFile.preview || '',
+          remote: true,
         });
         
         // Обновляем время последнего использования

--- a/frontend/components/mobile/MobileAddActionsDrawer.tsx
+++ b/frontend/components/mobile/MobileAddActionsDrawer.tsx
@@ -174,6 +174,7 @@ export default function MobileAddActionsDrawer({
           type: file.type,
           size: file.size,
           preview: previewUrl || file.preview || '',
+          remote: true,
         });
         
         const updated = recentFiles.map(f => 


### PR DESCRIPTION
## Summary
- add missing `remote: true` in `RecentFilesDropdown` and `MobileAddActionsDrawer`

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6869055473fc832ba22c491a7480a839