### PR TITLE
Fix OpenAI endpoint

### DIFF
--- a/app/api/image-generation/route.ts
+++ b/app/api/image-generation/route.ts
@@ -95,7 +95,11 @@ export async function POST(req: NextRequest) {
       tools: [imageGenerationTool],
     };
 
-    const response = await fetch('https://api.openai.com/v1/responses', {
+    const baseUrl =
+      process.env.OPENAI_API_BASE_URL?.replace(/\/+$/, '') ||
+      'https://api.openai.com/v1';
+
+    const response = await fetch(`${baseUrl}/responses`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${apiKey}`,


### PR DESCRIPTION
## Summary
- make OpenAI API base URL configurable with `OPENAI_API_BASE_URL`

## Testing
- `pnpm lint`
- `pnpm exec vitest run` *(fails: Cannot find module '@storybook/nextjs-vite/preset')*

------
https://chatgpt.com/codex/tasks/task_e_6869225e6a4c832b92e73dd45c5c79c9