### PR TITLE
Fix alias imports

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+import { resolve } from 'path'
 
 const require = createRequire(import.meta.url)
 
@@ -97,6 +98,7 @@ const nextConfig = {
     // Optimize for better module resolution
     resolveAlias: {
       '@': './src',
+      '@frontend': './src/frontend',
     },
   },
   images: {
@@ -110,6 +112,11 @@ const nextConfig = {
   },
   eslint: {
     dirs: ['src/app', 'src/components'],
+  },
+  webpack(config) {
+    config.resolve.alias['@'] = resolve(__dirname, 'src');
+    config.resolve.alias['@frontend'] = resolve(__dirname, 'src/frontend');
+    return config;
   },
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@frontend/*": ["./src/frontend/*"]
     }
   },
   "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- support `@frontend` alias for components moved under `src/frontend`

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686c6ec50b7c832b9a4fb57b5304d62a