### PR TITLE
Fix DOM removal guards

### DIFF
--- a/src/frontend/components/AIImageGeneration.tsx
+++ b/src/frontend/components/AIImageGeneration.tsx
@@ -114,7 +114,9 @@ export default function AIImageGeneration({
       link.download = `generated-image-${Date.now()}-${index + 1}.${extension}`;
       document.body.appendChild(link);
       link.click();
-      document.body.removeChild(link);
+      if (link.parentNode) {
+        link.parentNode.removeChild(link);
+      }
       // Убираем всплывашку при успешном скачивании
     } catch (error) {
       console.error('Failed to download image:', error);

--- a/src/frontend/components/StreamingCodeBlock.tsx
+++ b/src/frontend/components/StreamingCodeBlock.tsx
@@ -40,7 +40,9 @@ function Codebar({ lang, codeString }: { lang: string; codeString: string }) {
     a.download = `code_snippet.${ext}`;
     document.body.appendChild(a);
     a.click();
-    document.body.removeChild(a);
+    if (a.parentNode) {
+      a.parentNode.removeChild(a);
+    }
     URL.revokeObjectURL(url);
   }, [codeString, lang]);
 

--- a/src/lib/copyText.ts
+++ b/src/lib/copyText.ts
@@ -13,7 +13,9 @@ export async function copyText(text: string) {
     try {
       document.execCommand('copy');
     } finally {
-      document.body.removeChild(textarea);
+      if (textarea.parentNode) {
+        textarea.parentNode.removeChild(textarea);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- handle missing parent nodes when removing DOM elements

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686d13c207ac832b8ff8e3fe8fa481aa