### PR TITLE
Fix DOM removal errors

### DIFF
--- a/src/frontend/components/AIImageGeneration.tsx
+++ b/src/frontend/components/AIImageGeneration.tsx
@@ -115,7 +115,8 @@ export default function AIImageGeneration({
       document.body.appendChild(link);
       link.click();
       if (link.parentNode) {
-        link.parentNode.removeChild(link);
+        // Избегаем ошибки NotFound при повторном удалении
+        link.remove();
       }
       // Убираем всплывашку при успешном скачивании
     } catch (error) {

--- a/src/frontend/components/StreamingCodeBlock.tsx
+++ b/src/frontend/components/StreamingCodeBlock.tsx
@@ -41,7 +41,8 @@ function Codebar({ lang, codeString }: { lang: string; codeString: string }) {
     document.body.appendChild(a);
     a.click();
     if (a.parentNode) {
-      a.parentNode.removeChild(a);
+      // Безопасно удаляем созданную ссылку
+      a.remove();
     }
     URL.revokeObjectURL(url);
   }, [codeString, lang]);

--- a/src/frontend/hooks/useRippleEffect.ts
+++ b/src/frontend/hooks/useRippleEffect.ts
@@ -88,7 +88,8 @@ export const useRippleEffect = (options: RippleEffectOptions = {}) => {
     // Удаляем ripple после анимации
     setTimeout(() => {
       if (ripple.parentNode) {
-        ripple.parentNode.removeChild(ripple);
+        // Используем remove() для избежания NotFoundError
+        ripple.remove();
       }
     }, duration);
   }, [color, duration, disabled, forceEnable]);

--- a/src/lib/copyText.ts
+++ b/src/lib/copyText.ts
@@ -14,7 +14,8 @@ export async function copyText(text: string) {
       document.execCommand('copy');
     } finally {
       if (textarea.parentNode) {
-        textarea.parentNode.removeChild(textarea);
+        // Удаляем временный textarea безопасно
+        (textarea as HTMLTextAreaElement).remove();
       }
     }
   }


### PR DESCRIPTION
## Summary
- safely remove temporary DOM elements to avoid NotFoundError

## Testing
- `pnpm lint`
- `pnpm exec vitest run` *(fails: Cannot find module '@storybook/nextjs-vite/preset')*

------
https://chatgpt.com/codex/tasks/task_e_686d17edc068832bbe03a111a7335c49