### PR TITLE
Fix build errors in hooks and chat history list

### DIFF
--- a/src/frontend/components/chat-history/components/FastChatHistoryList.tsx
+++ b/src/frontend/components/chat-history/components/FastChatHistoryList.tsx
@@ -400,11 +400,7 @@ function FastChatHistoryList({
   // Показываем пустое состояние если нет тредов
   if (!threads || threads.length === 0) {
     return (
-      <EmptyState
-        type="no-chats"
-        title="No chat history"
-        hint="Start chatting to build your history"
-      />
+      <EmptyState type="no-history" />
     );
   }
 

--- a/src/frontend/hooks/useLongPress.ts
+++ b/src/frontend/hooks/useLongPress.ts
@@ -16,7 +16,7 @@ export function useLongPress({
   const [isPressed, setIsPressed] = useState(false);
  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const preventClickRef = useRef(false);
-  const resetTimeoutRef = useRef<number | null>(null);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const start = useCallback((event: React.TouchEvent | React.MouseEvent) => {
     if (!isMobile) return;


### PR DESCRIPTION
## Summary
- correct `EmptyState` usage in `FastChatHistoryList`
- use proper timeout ref type in `useLongPress`

## Testing
- `pnpm run lint`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_687527eca7f0832ba73253e2c20a53ec