### PR TITLE
Fix threadId validation and message persistence issues

### DIFF
--- a/src/app/api/llm-google/route.ts
+++ b/src/app/api/llm-google/route.ts
@@ -39,7 +39,10 @@ export async function POST(req: NextRequest) {
       attachments: requestAttachments,
     } = await req.json();
 
-    if (!threadId && messages.length > 1) {
+    // Для нового чата threadId может быть пустым - это нормально
+    // Но если есть больше одного сообщения пользователя, threadId обязателен
+    const userMessagesCount = messages.filter(m => m.role === 'user').length;
+    if (!threadId && userMessagesCount > 1) {
       return NextResponse.json(
         { error: 'threadId required for existing conversations' },
         { status: 400 }

--- a/src/app/api/llm/route.ts
+++ b/src/app/api/llm/route.ts
@@ -54,8 +54,9 @@ export async function POST(req: NextRequest) {
     }
 
     // Для нового чата threadId может быть пустым - это нормально
-    // Проверяем только если есть сообщения, которые нужно сохранить в БД
-    if (!threadId && messages.length > 1) {
+    // Но если есть больше одного сообщения пользователя, threadId обязателен
+    const userMessagesCount = messages.filter(m => m.role === 'user').length;
+    if (!threadId && userMessagesCount > 1) {
       return NextResponse.json(
         { error: 'threadId required for existing conversations' },
         { status: 400 }

--- a/src/frontend/components/ChatView.tsx
+++ b/src/frontend/components/ChatView.tsx
@@ -142,7 +142,8 @@ const ChatView = React.memo(function ChatView({
   // Мемоизируем функцию подготовки тела запроса
   const prepareRequestBody = useCallback(
     ({ messages, ...options }: { messages: UIMessage[]; [key: string]: any }) => {
-      const currentThreadId = threadIdRef.current;
+      // Используем threadId из options если он есть, иначе из ref
+      const currentThreadId = options.threadId || threadIdRef.current;
       const { isImageGenerationMode, imageGenerationParams } = useChatStore.getState();
       // Get current mode information
       const currentMode = getSelectedMode();
@@ -352,7 +353,8 @@ const ChatView = React.memo(function ChatView({
       return response;
     },
     onFinish: async (finalMsg) => {
-      const latestThreadId = threadIdRef.current;
+      // Get the latest threadId from multiple sources
+      const latestThreadId = threadIdRef.current || currentThreadId;
       
       // Save only assistant messages to database (user messages already saved in useChatSubmit)
       if (

--- a/src/frontend/components/chat-input/hooks/useChatSubmit.ts
+++ b/src/frontend/components/chat-input/hooks/useChatSubmit.ts
@@ -314,19 +314,23 @@ export const useChatSubmit = ({
       } : undefined;
 
       // Send to LLM (use DB message ID to avoid duplication)
+      // ВАЖНО: Передаем ensuredThreadId в body, чтобы API получил правильный threadId
       append(
         createUserMessage(dbMsgId, finalMessage, attachmentsForUI),
         {
           body: {
             model: selectedModel,
             apiKeys: keys,
-            threadId: ensuredThreadId,
+            threadId: ensuredThreadId, // Обязательно передаем правильный threadId
             userId: user?.uid,
             search: webSearchEnabled,
             attachments: attachmentsForLLM,
             imageGeneration: imageGenerationData,
             customMode: customModeData,
             projectId: projectId,
+          },
+          options: {
+            threadId: ensuredThreadId, // Дублируем для надежности
           },
         }
       );


### PR DESCRIPTION
- Fix threadId validation to only count user messages, preventing error on second message
- Ensure assistant messages are properly saved to database by using correct threadId
- Update prepareRequestBody to use threadId from options when available
- Apply same fixes to both main and Google-specific API endpoints