### PR TITLE
Update attachments type in llm-google API route

### DIFF
--- a/src/app/api/llm-google/route.ts
+++ b/src/app/api/llm-google/route.ts
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest) {
       threadId?: string;
       userId?: string;
       search?: boolean;
-      attachments?: any[];
+      attachments?: Attachment[];
     } = await req.json();
 
     // Для нового чата threadId может быть пустым - это нормально


### PR DESCRIPTION
Changed the type of the 'attachments' field from 'any[]' to 'Attachment[]' in the POST handler to improve type safety and clarity.