### PR TITLE
Fix long ai message scroll and press bug

### DIFF
--- a/src/frontend/components/message/Message.tsx
+++ b/src/frontend/components/message/Message.tsx
@@ -102,13 +102,14 @@ const PureMessage = memo(function PureMessage({
     router.push(`/chat`);
   }, [router]);
 
-  const { bind, isPressed } = useLongPress({
+  const { bind } = useLongPress({
     onLongPress: () => {
-      if (!isWelcome) { 
+      if (!isWelcome) {
         setShowMobileModal(true);
       }
     },
     isMobile,
+    threshold: 650,
   });
 
   // Извлекаем reasoning из первой текстовой части с мемоизацией
@@ -328,8 +329,7 @@ const PureMessage = memo(function PureMessage({
               key={key}
               className={cn(
                 'relative group px-4 py-3 rounded-xl bg-secondary border border-secondary-foreground/2 max-w-[90%] sm:max-w-[80%] mx-2 sm:mx-0 transition-all duration-200',
-                isMobile && 'cursor-pointer',
-                isPressed && 'scale-95 opacity-70'
+                isMobile && 'cursor-pointer'
               )}
               {...bind}
             >
@@ -409,8 +409,7 @@ const PureMessage = memo(function PureMessage({
               key={key}
               className={cn(
                 'group flex flex-col gap-2 w-full px-2 sm:px-0 transition-all duration-200',
-                isMobile && 'cursor-pointer',
-                isPressed && 'scale-95 opacity-70'
+                isMobile && 'cursor-pointer'
               )}
               {...bind}
             >

--- a/src/frontend/hooks/useLongPress.ts
+++ b/src/frontend/hooks/useLongPress.ts
@@ -5,6 +5,7 @@ interface UseLongPressOptions {
   onCancel?: () => void;
   threshold?: number; // время в миллисекундах для долгого нажатия
   isMobile?: boolean;
+  movementThreshold?: number; // пиксели перемещения, после которых считаем жест прокруткой
 }
 
 export function useLongPress({
@@ -12,39 +13,40 @@ export function useLongPress({
   onCancel,
   threshold = 500, // 500ms по умолчанию
   isMobile = false,
+  movementThreshold = 8, // по умолчанию 8px допускается до отмены (скролл)
 }: UseLongPressOptions) {
   const [isPressed, setIsPressed] = useState(false);
- const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const preventClickRef = useRef(false);
   const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startXRef = useRef<number | null>(null);
+  const startYRef = useRef<number | null>(null);
+  const longPressFiredRef = useRef(false);
 
   const start = useCallback((event: React.TouchEvent | React.MouseEvent) => {
     if (!isMobile) return;
-    
-    // Сохраняем тип события для использования в таймауте
+
     const eventType = event.type;
-    
-    // Предотвращаем выделение текста при долгом нажатии только для touch событий
+
+    // Не вызываем preventDefault на touchstart, чтобы не ломать скролл и нативные жесты
+    // Сохраняем стартовые координаты для определения скролла
     if (eventType === 'touchstart') {
-      event.preventDefault();
+      const touch = (event as React.TouchEvent).touches[0];
+      startXRef.current = touch.clientX;
+      startYRef.current = touch.clientY;
     }
-    
-    // Не устанавливаем isPressed сразу для touch событий
+
     if (eventType !== 'touchstart') {
       setIsPressed(true);
     }
-    // Сбрасываем флаг только при начале нового взаимодействия
     preventClickRef.current = false;
-    
+    longPressFiredRef.current = false;
+
     timeoutRef.current = setTimeout(() => {
-      if (eventType === 'touchstart') {
-        setIsPressed(true);
-      }
+      setIsPressed(true);
+      longPressFiredRef.current = true;
       onLongPress();
       preventClickRef.current = true;
-      // НЕ сбрасываем isPressed здесь - пусть cancel() это сделает
-      
-      // Добавляем небольшую вибрацию для обратной связи (если поддерживается)
       if (navigator.vibrate) {
         navigator.vibrate(50);
       }
@@ -56,25 +58,35 @@ export function useLongPress({
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
     }
-    
-    // Очищаем предыдущий reset таймаут если он есть
+
+    setIsPressed(false);
+
     if (resetTimeoutRef.current) {
       clearTimeout(resetTimeoutRef.current);
     }
-    
-    setIsPressed(false);
-    
-    // Добавляем задержку для сброса флага, чтобы избежать race condition
-    // между onTouchEnd и onClick
     resetTimeoutRef.current = setTimeout(() => {
       preventClickRef.current = false;
       resetTimeoutRef.current = null;
     }, 100);
-    
-    if (onCancel) {
+
+    if (onCancel && !longPressFiredRef.current) {
       onCancel();
     }
   }, [onCancel]);
+
+  const handleTouchMove = useCallback((event: React.TouchEvent) => {
+    if (!isMobile) return;
+    if (timeoutRef.current == null) return;
+
+    const touch = event.touches[0];
+    const dx = Math.abs(touch.clientX - (startXRef.current ?? touch.clientX));
+    const dy = Math.abs(touch.clientY - (startYRef.current ?? touch.clientY));
+
+    if (dx > movementThreshold || dy > movementThreshold) {
+      // Пользователь начал прокрутку — отменяем долгий тап и даем скроллить
+      cancel();
+    }
+  }, [cancel, isMobile, movementThreshold]);
 
   const handleClick = useCallback((event: React.MouseEvent) => {
     if (preventClickRef.current) {
@@ -84,7 +96,6 @@ export function useLongPress({
     }
   }, []);
 
-  // Cleanup функция для очистки таймаутов
   const cleanup = useCallback(() => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
@@ -94,6 +105,9 @@ export function useLongPress({
       clearTimeout(resetTimeoutRef.current);
       resetTimeoutRef.current = null;
     }
+    startXRef.current = null;
+    startYRef.current = null;
+    longPressFiredRef.current = false;
   }, []);
 
   const bind = {
@@ -103,13 +117,13 @@ export function useLongPress({
     onTouchStart: start,
     onTouchEnd: cancel,
     onTouchCancel: cancel,
-    onTouchMove: cancel,
+    onTouchMove: handleTouchMove,
     onClick: handleClick,
-  };
+  } as const;
 
   return {
     bind,
     isPressed,
     cleanup,
-  };
+  } as const;
 }


### PR DESCRIPTION
Fixes mobile long-press and scrolling issues by adjusting touch event handling and removing unwanted visual effects.

Previously, long AI messages could prevent scrolling due to `preventDefault` on `touchstart`. This PR removes that, introduces a movement threshold to cancel long-press during scrolling, and standardizes the long-press delay to 650ms. It also removes the unwanted "pressed" visual effect on mobile for AI messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-764c37ad-b8b3-4e72-a828-eddedd0b9bb6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-764c37ad-b8b3-4e72-a828-eddedd0b9bb6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

