### PR TITLE
Move project title above chat input on project page

### DIFF
--- a/src/features/projects/pages/ProjectPage.tsx
+++ b/src/features/projects/pages/ProjectPage.tsx
@@ -10,7 +10,7 @@ import Chat from "@/frontend/components/Chat";
 import { Button } from "@/components/ui/button";
 import { WithTooltip } from "@/frontend/components/WithTooltip";
 import { Settings, Plus } from "lucide-react";
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import SettingsDrawer from "@/frontend/components/SettingsDrawer";
 import { ChatHistoryButton } from "@/frontend/components/chat-history";
 import { saveLastPath, saveLastChatId } from "@/frontend/lib/lastChat";
@@ -97,8 +97,15 @@ export default function ProjectPage() {
     );
   }
 
+  const projectHeaderContent = useMemo(() => (
+    <ProjectHeader
+      project={project}
+      onUpdate={(updates) => updateProject(updates)}
+    />
+  ), [project, updateProject]);
+
   return (
-    	<>
+    <>
       <div className="min-h-screen bg-background relative">
         {/* Top-left navigation */}
         <div className="fixed left-4 top-4 z-50 pointer-events-auto">
@@ -152,34 +159,25 @@ export default function ProjectPage() {
             {/* Left side - Project info and chat input */}
             <div className={currentChatId ? "w-full min-h-screen flex flex-col pointer-events-auto" : "flex-1 lg:flex-initial lg:w-[calc(100%-500px)] p-8 pr-4 flex flex-col pointer-events-auto"}>
               <div className={currentChatId ? "w-full flex flex-col h-full pointer-events-auto" : "w-full flex flex-col h-full pointer-events-auto"}>
-                {/* Project header - верхняя часть (если нет активного чата) */}
-                {!currentChatId && (
-                  <div className="mb-4 flex-shrink-0">
-                    <ProjectHeader
-                      project={project}
-                      onUpdate={(updates) => updateProject(updates)}
-                    />
-                  </div>
-                )}
-                
                 {/* Chat component - full height */}
                 <div className="flex-1 flex flex-col">
                   <div className={currentChatId ? "flex-1 w-full" : "flex-1 flex items-start justify-start"}>
                     <div className={currentChatId ? "w-full h-full" : "w-full [&_.fixed.left-1\/2]:left-[20%]"}>
                       <Chat
-                           key={`project-home-${projectId}-${currentChatId || 'new'}`} // Уникальный ключ для каждого состояния
-                           threadId={currentChatId || "new"}
-                           thread={null}
-                           initialMessages={[]}
-                           projectId={projectId}
-                           project={project}
-                           customLayout={false} // Используем стандартный layout как на обычной странице
-                           projectLayout={!currentChatId} // Добавляем флаг для особого позиционирования на странице проекта
-                           onThreadCreated={handleThreadCreated}
-                         />
-                      </div>
+                        key={`project-home-${projectId}-${currentChatId || 'new'}`} // Уникальный ключ для каждого состояния
+                        threadId={currentChatId || "new"}
+                        thread={null}
+                        initialMessages={[]}
+                        projectId={projectId}
+                        project={project}
+                        customLayout={false} // Используем стандартный layout как на обычной странице
+                        projectLayout={!currentChatId} // Добавляем флаг для особого позиционирования на странице проекта
+                        projectHeader={!currentChatId ? projectHeaderContent : undefined}
+                        onThreadCreated={handleThreadCreated}
+                      />
                     </div>
                   </div>
+                </div>
               </div>
             </div>
             

--- a/src/frontend/components/Chat.tsx
+++ b/src/frontend/components/Chat.tsx
@@ -29,10 +29,21 @@ interface ChatProps {
   customLayout?: boolean; // Для специальных layout'ов
   projectLayout?: boolean; // Для особого позиционирования на странице проекта
   onThreadCreated?: (threadId: Id<'threads'>) => void;
+  projectHeader?: React.ReactNode;
 }
 
 // Мемоизированный компонент Chat
-const Chat = React.memo(function Chat({ threadId, thread, initialMessages, projectId, project, customLayout, projectLayout, onThreadCreated }: ChatProps) {
+const Chat = React.memo(function Chat({
+  threadId,
+  thread,
+  initialMessages,
+  projectId,
+  project,
+  customLayout,
+  projectLayout,
+  onThreadCreated,
+  projectHeader,
+}: ChatProps) {
   const { isMobile } = useIsMobile();
   const { selectedModel } = useModelStore();
   const router = useRouter();
@@ -262,6 +273,7 @@ const Chat = React.memo(function Chat({ threadId, thread, initialMessages, proje
           project={project}
           customLayout={customLayout}
           projectLayout={projectLayout}
+          projectHeader={projectHeader}
         />
       </div>
     </div>

--- a/src/frontend/components/ChatView.tsx
+++ b/src/frontend/components/ChatView.tsx
@@ -34,19 +34,21 @@ interface ChatViewProps {
   project?: Doc<"projects">;
   customLayout?: boolean;
   projectLayout?: boolean;
+  projectHeader?: React.ReactNode;
 }
 
 // Мемоизированный компонент ChatView
-const ChatView = React.memo(function ChatView({ 
-  threadId, 
-  thread, 
-  initialMessages, 
-  showNavBars, 
+const ChatView = React.memo(function ChatView({
+  threadId,
+  thread,
+  initialMessages,
+  showNavBars,
   onThreadCreated,
   projectId,
   project,
   customLayout,
-  projectLayout
+  projectLayout,
+  projectHeader
 }: ChatViewProps) {
   const { keys } = useAPIKeyStore();
   const { selectedModel, webSearchEnabled } = useModelStore();
@@ -722,24 +724,31 @@ const ChatView = React.memo(function ChatView({
             !customLayout && (isMobile ? 'bottom-0' : (hasAnyMessages ? 'bottom-0' : 'top-1/2 -translate-y-1/2')),
           )}
         >
-          
-          <LazyChatInput
-            threadId={currentThreadId}
-            thread={thread}
-            input={input}
-            status={status}
-            reload={reload}
-            setInput={setInput}
-            setMessages={setMessages}
-            append={append}
-            stop={stopWithCleanup}
-            error={error}
-            messageCount={mergedMessages.length}
-            onThreadCreated={handleThreadCreated}
-            projectId={projectId}
-            sessionThreadId={sessionThreadId}
-            setSessionThreadId={setSessionThreadId}
-          />
+          <div className="flex w-full flex-col items-start gap-3">
+            {projectLayout && projectHeader && (
+              <div className="pl-2 text-left">
+                {projectHeader}
+              </div>
+            )}
+
+            <LazyChatInput
+              threadId={currentThreadId}
+              thread={thread}
+              input={input}
+              status={status}
+              reload={reload}
+              setInput={setInput}
+              setMessages={setMessages}
+              append={append}
+              stop={stopWithCleanup}
+              error={error}
+              messageCount={mergedMessages.length}
+              onThreadCreated={handleThreadCreated}
+              projectId={projectId}
+              sessionThreadId={sessionThreadId}
+              setSessionThreadId={setSessionThreadId}
+            />
+          </div>
         </div>
       </div>
     </>

--- a/src/frontend/components/lazy/LazyChatView.tsx
+++ b/src/frontend/components/lazy/LazyChatView.tsx
@@ -18,6 +18,7 @@ interface LazyChatViewProps {
   project?: Doc<"projects">;
   customLayout?: boolean;
   projectLayout?: boolean;
+  projectHeader?: React.ReactNode;
 }
 
 // Skeleton component for ChatView loading state
@@ -74,7 +75,7 @@ function ChatViewSkeleton() {
 
 export default function LazyChatView(props: LazyChatViewProps) {
   const hasMessages = props.initialMessages && props.initialMessages.length > 0;
-  
+
   return (
     <Suspense fallback={hasMessages ? null : <ChatViewSkeleton />}>
       <ChatView {...props} />


### PR DESCRIPTION
## Summary
- repositioned the editable project header into the project chat area so it sits just above the input on the home view
- updated chat components to accept and render an optional project header for project layouts

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cb257f4b3083319adddb2964afc553