### PR TITLE
Fix CSS chunk script execution

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -93,15 +93,13 @@ const nextConfig = {
   webpack: (config, { dev, isServer }) => {
     // Оптимизация для мобильных устройств
     if (!dev && !isServer) {
-      // Разделяем вендорные библиотеки
+      // Создаем целевые группы для чанков, не нарушая дефолтную конфигурацию Next.js
+      const splitChunks = config.optimization?.splitChunks ?? {};
+
       config.optimization.splitChunks = {
-        chunks: 'all',
+        ...splitChunks,
         cacheGroups: {
-          vendor: {
-            test: /[\\/]node_modules[\\/]/,
-            name: 'vendors',
-            chunks: 'all',
-          },
+          ...(splitChunks?.cacheGroups ?? {}),
           // Отдельный чанк для Convex
           convex: {
             test: /[\\/]node_modules[\\/]convex[\\/]/,


### PR DESCRIPTION
## Summary
- preserve Next.js default splitChunks configuration while adding convex and UI cache groups to prevent CSS assets from being injected as scripts

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68cb2b960bec83319e27d12ab37aa089