### PR TITLE
Fix webpack splitChunks configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -92,32 +92,21 @@ const nextConfig = {
   // Оптимизация бандла
   webpack: (config, { dev, isServer }) => {
     // Оптимизация для мобильных устройств
-    if (!dev && !isServer) {
-      // Создаем целевые группы для чанков, не нарушая дефолтную конфигурацию Next.js
-      const splitChunks = config.optimization?.splitChunks ?? {};
-
-      config.optimization.splitChunks = {
-        ...splitChunks,
-        cacheGroups: {
-          ...(splitChunks?.cacheGroups ?? {}),
-          // Отдельный чанк для Convex
-          convex: {
-            test: /[\\/]node_modules[\\/]convex[\\/]/,
-            name: 'convex',
-            chunks: 'all',
-            priority: 10,
-          },
-          // Отдельный чанк для UI компонентов
-          ui: {
-            test: /[\\/]src[\\/]components[\\/]ui[\\/]/,
-            name: 'ui',
-            chunks: 'all',
-            priority: 5,
-          },
-        },
+    if (!dev && !isServer && config.optimization?.splitChunks?.cacheGroups) {
+      // Добавляем дополнительные группы чанков, не переопределяя конфигурацию Next.js
+      config.optimization.splitChunks.cacheGroups.convex = {
+        test: /[\\/]node_modules[\\/]convex[\\/]/,
+        name: 'convex',
+        chunks: 'all',
+        priority: 10,
       };
-      // Оптимизация размера бандла
-      config.optimization.minimize = true;
+
+      config.optimization.splitChunks.cacheGroups.ui = {
+        test: /[\\/]src[\\/]components[\\/]ui[\\/]/,
+        name: 'ui',
+        chunks: 'all',
+        priority: 5,
+      };
     }
 
     // Оптимизация для мобильных устройств


### PR DESCRIPTION
## Summary
- avoid overwriting Next.js' default splitChunks configuration in the custom webpack hook
- append convex and ui cache groups only when the defaults exist so Next.js can generate the expected assets

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68cd7b17da6c83318278f981a79998c9